### PR TITLE
Jlorincz/fixed output type request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 data/*
 *.pyc
 *.csv
+*.hdf5
+*.h5
 *~
 *.egg-info/*
 .vscode/*

--- a/disruption_py/settings/output_type_request.py
+++ b/disruption_py/settings/output_type_request.py
@@ -194,16 +194,16 @@ class HDF5OutputRequest(OutputTypeRequest):
     """
     def __init__(self, filepath):
         self.filepath = filepath
-        self.store = pd.HDFStore(filepath, mode='w')
         self.output_shot_count = 0
 
     def _output_shot(self, params : ResultOutputTypeRequestParams):
         shot_id = params.result['shot'].iloc[0] if (not params.result.empty and ('shot' in params.result.columns)) else self.output_shot_count
-        self.store.append(f'df_{shot_id}', params.result, format='table', data_columns=True)
+        mode = 'a' if self.output_shot_count > 0 else 'w'
+        params.result.to_hdf(self.filepath, f'df_{shot_id}', format='table', complib='blosc', mode=mode)
         self.output_shot_count += 1
     
     def stream_output_cleanup(self, params: FinishOutputTypeRequestParams):
-        self.store.close()
+        pass
     
     def get_results(self, params: FinishOutputTypeRequestParams):
         return self.output_shot_count

--- a/docs/api/requests/output_type_request_reference.md
+++ b/docs/api/requests/output_type_request_reference.md
@@ -1,13 +1,13 @@
 ## Overview { .doc .doc-heading }
-A module for handling output type requests passed in the [`ShotSettings`][disruption_py.settings.ShotSettings] class. 
-Output type requests are used to handle the output of data from disruption_py as it is retrieved. This may inlude collecting all the data from a request and returning it as a list or streaming outputted data to a file as it is retrieved.
+A module for handling output type requests passed in the [`get_shots_data`][disruption_py.handlers.cmod_handler.CModHandler.get_shots_data] 
+method. Output type requests are used to handle the output of data from disruption_py as it is retrieved. This may inlude collecting all the data from a request and returning it as a list or streaming outputted data to a file as it is retrieved.
 
 This module defines the abstract class [`OutputTypeRequest`][disruption_py.settings.output_type_request.OutputTypeRequest] that can have subclasses passed as the
-`output_type_request` parameter to the `ShotSettings` class.
+`output_type_request` argument to the `get_shots_data` method.
 It also provides built_in classes and mappings to easily set the output type for common use cases.
 
 ### Usage { .doc .doc-heading }
-Currently, these are the options that can be passed to the `output_type_request` parameter in `ShotSettings`:
+Currently, these are the options that can be passed as the `output_type_request` argument to `get_shots_data`:
 
 - An instance of a subclass of `OutputTypeRequest`
 - A string identifier in the `_output_type_request_mappings` dictionary:
@@ -24,7 +24,7 @@ disruption_py/settings/output_type_request.py:output_type_request_dict
 	```
 - A dictionary mapping tokamak type strings to the desired `OutputTypeRequest` for that tokamak.  E.g. `{'cmod': 'efit'}`.
 	--8<-- "disruption_py/utils/mappings/tokamak.py:allowed_tokamak_types_snippet"
-- A python list of any other output type request option that can be passed as the `output_type_request` parameter in `ShotSettings` (all options listed previously). See [`OutputTypeRequestList`][disruption_py.settings.output_type_request.OutputTypeRequestList] for more details.
+- A python list of any other output type request option that can be passed as the `output_type_request` argument to `get_shots_data` (all options listed previously). See [`OutputTypeRequestList`][disruption_py.settings.output_type_request.OutputTypeRequestList] for more details.
 
 ## Built-in Implemenations { .doc .doc-heading }
 ::: disruption_py.settings.output_type_request

--- a/docs/api/requests/shot_ids_request_reference.md
+++ b/docs/api/requests/shot_ids_request_reference.md
@@ -1,9 +1,8 @@
 ## Overview { .doc .doc-heading }
 A module for handling shot ids requests passed in the [`get_shots_data`][disruption_py.handlers.cmod_handler.CModHandler.get_shots_data] 
-function. Shot ids requests are used by disruption_py to get the shot ids of shots that should have data retrieved from MDSplus.
+method. Shot ids requests are used by disruption_py to get the shot ids of shots that should have data retrieved from MDSplus.
 
-This module defines the abstract class [`ShotIdsRequest`][disruption_py.settings.shot_ids_request.ShotIdsRequest] that can have subclasses passed as the `shot_ids_request`
-argument to the `get_shots_data` function.
+This module defines the abstract class [`ShotIdsRequest`][disruption_py.settings.shot_ids_request.ShotIdsRequest] that can have subclasses passed as the `shot_ids_request` argument to the `get_shots_data` method.
 It also provides built_in classes and mappings to easily define shot ids for common use cases.
 
 ### Usage { .doc .doc-heading }

--- a/docs/quickstart/usage_quickstart.md
+++ b/docs/quickstart/usage_quickstart.md
@@ -37,9 +37,6 @@ Creating a scripts gives you the full functionality of disruption_py.
 		
 		# run all available methods
 		run_tags=["all"],
-		
-		# stream retrieved data to the csv file
-		output_type_request="ip_data.csv", 
 	)
 	```
 
@@ -60,6 +57,9 @@ Creating a scripts gives you the full functionality of disruption_py.
 
 		# use the created shot_settings
 		shot_settings=shot_settings,
+
+		# stream retrieved data to the csv file
+		output_type_request="ip_data.csv", 
 
 		# use a single process to retrieve the data
 		num_processes = 1,

--- a/examples/basic_example_1.py
+++ b/examples/basic_example_1.py
@@ -9,12 +9,14 @@ shot_settings = ShotSettings(
     
     # run all available methods
     run_tags=["all"],
-    
-    # automatically stream retrieved data to a csv file by passing in a file path ending in .csv
-    output_type_request="ip_data.csv", 
 )
 shot_data = cmod_handler.get_shots_data(
-    shot_ids_request=[1150805012, 1150805013, 1150805014,], # Retrieve data for the desired shots
+    # Retrieve data for the desired shots
+    shot_ids_request=[1150805012, 1150805013, 1150805014],
     shot_settings=shot_settings,
-    num_processes = 1,
+    
+    # automatically stream retrieved data to a csv file by passing in a file path ending in .csv
+    output_type_request="ip_data.csv",
+    
+    num_processes = 1
 )

--- a/examples/basic_example_2.py
+++ b/examples/basic_example_2.py
@@ -15,15 +15,19 @@ shot_settings = ShotSettings(
     # run the get_ip_parameters method
     run_methods=["_get_ip_parameters"],
     run_tags=[],
+    
     # run the method that  returns the ne_peaking column
     run_columns=["ne_peaking"],
+)
+shot_data = cmod_handler.get_shots_data(
+    # use the shot ids listed in the shot_ids_of_interest.txt file
+    shot_ids_request="shot_ids_of_interest.txt",
+    shot_settings=shot_settings,
     
     # automatically stream retrieved data to a csv file by passing in a file path ending in .csv
     # this works by automatically using the CSVOutputRequest preset with the passed filename
     output_type_request="ip_data.csv", 
-)
-shot_data = cmod_handler.get_shots_data(
-    shot_ids_request="shot_ids_of_interest.txt", # use the shot ids listed in the shot_ids_of_interest.txt file
-    shot_settings=shot_settings,
-    num_processes = 4, # retrieve data quickly using 4 processes
+    
+    # retrieve data quickly using 4 processes
+    num_processes = 4,
 )

--- a/examples/custom_shot_id_request.py
+++ b/examples/custom_shot_id_request.py
@@ -15,13 +15,18 @@ class CustomShotIdRequest(ShotIdsRequest):
 
 cmod_handler = CModHandler()
 shot_settings = ShotSettings(
-    set_times_request="efit", # use the efit timebase preset for set_times_request
+    # use the efit timebase preset for set_times_request
+    set_times_request="efit",
     run_tags=[],
-    run_methods=["_get_ip_parameters"], # only run thr get_ip_parameters method
-    output_type_request="ip_data.csv", # automatically uses the CSVOutputRequest preset because of the .csv file descriptor
+    
+    # only run thr get_ip_parameters method
+    run_methods=["_get_ip_parameters"],
 )
 shot_data = cmod_handler.get_shots_data(
     shot_id_request=CustomShotIdRequest(),
     shot_settings=shot_settings,
+    
+    # automatically uses the CSVOutputRequest preset because of the .csv file descriptor
+    output_type_request="ip_data.csv",
     num_processes = 4,
 )

--- a/test/test_cmod_mini.py
+++ b/test/test_cmod_mini.py
@@ -1,16 +1,32 @@
+import logging
+import sys
+
+sys.path.append("/home/joshlor/Documents/disruption-py/")
+from disruption_py.settings.log_settings import LogSettings
 from disruption_py.handlers.cmod_handler import CModHandler
-from disruption_py.settings import ShotSettings
+from disruption_py.settings.shot_settings import ShotSettings
 
 cmod_handler = CModHandler()
 shot_settings = ShotSettings(
-	existing_data_request="sql",
-	set_times_request="magnetics004",
-	run_tags=[],
-	run_methods=["_get_ip_parameters"],
-	output_type_request="ip_data.csv",
+    # uses the efit timebase when returning data 
+    set_times_request="efit",
+    
+    # run all available methods
+    run_tags=["all"],
+    
+    efit_tree_name="efit18",
+    
+    log_settings=LogSettings(console_log_level=logging.DEBUG),
+    
 )
-cmod_handler.get_shots_data(
-	shot_ids_request=[1160405002, 1140523021, 1140523026, 1160620011],
-	shot_settings=shot_settings,
-	num_processes = 4,
+
+shot_data = cmod_handler.get_shots_data(
+    shot_ids_request=[1160405002, 1140523021, 1140523026, 1160620011], # Retrieve data for the desired shots
+    shot_settings=shot_settings,
+    
+    # automatically stream retrieved data to a csv file by passing in a file path ending in .csv
+    output_type_request="test/ip_data.hdf5", 
+    
+    num_processes=1,
 )
+


### PR DESCRIPTION
There were issues where output_type request objects that were not serializable would fail when multiprocessing. This is fixed by moving the output type request to get_shots_data instead of being inside of the shot_settings
