### PR TITLE
Fix documentation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 ---
-site_name: My Docs
+site_name: DisruptionPy Documentation
 theme:
   name: material
   features:
@@ -34,10 +34,12 @@ nav:
       - Settings:
           - Settings Classes: usage/settings_reference.md
           - Requests Classes:
-              - Existing Data Request: usage/requests/existing_data_request_reference.md
+              - Existing Data Request: >-
+                  usage/requests/existing_data_request_reference.md
               - Shot Ids Request: usage/requests/shot_ids_request_reference.md
               - Set Times Request: usage/requests/set_times_request_reference.md
-              - Output Type Request: usage/requests/output_type_request_reference.md
+              - Output Type Request: >-
+                  usage/requests/output_type_request_reference.md
               - Shot Data Request: usage/requests/shot_data_request_reference.md
       - Shots:
           - Parameter Methods:
@@ -100,9 +102,3 @@ plugins:
             show_root_full_path: true
             show_root_members_full_path: false
             show_object_full_path: false
-
-            # Premium options (not able to use)
-            # show_symbol_type_heading: true  # super useful
-            # show_symbol_type_toc: true  # super useful
-            # summary: true  # super useful
-#  - argparse_to_md


### PR DESCRIPTION
- fixed documentation title
- validated YAML file
- fixed line endings from windows to unix

current output:
```
INFO  -  The following pages exist in the docs directory, but are not included in the "nav" configuration:
      - contributing.md
```
is that something we need to link in the main body of the docs?