### PR TITLE
fix version for dev

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "disruption-py"
-version = "0.8.0"
+version = "0.4.0"
 description = ""
 authors = ["Joshua Lorincz <26237613+lajz@users.noreply.github.com>"]
 license = "MIT"


### PR DESCRIPTION
roll back to 0.4.0 for `develop`, as we are very much still under active development.