### PR TITLE
Fix multiprocessing bug

### DIFF
--- a/disruption_py/handlers/multiprocessing_helper.py
+++ b/disruption_py/handlers/multiprocessing_helper.py
@@ -125,6 +125,9 @@ class MultiprocessingShotRetriever:
             self.task_queue.put(MARK_COMPLETE)
         self.task_queue.join()
         
+        for consumer in self.consumers:
+            consumer.join()
+
         # Signal the result processing thread to stop once completed processing and wait for it to finish
         self.result_queue.put((None, MARK_COMPLETE))
         self.result_thread.join()


### PR DESCRIPTION
Fix an issue where if tasks are processed too fast in multiprocessing, the result processing thread will stop before processing all results.