### PR TITLE
Drop usage of importlib resources

### DIFF
--- a/disruption_py/settings/shot_ids_request.py
+++ b/disruption_py/settings/shot_ids_request.py
@@ -10,11 +10,7 @@ from logging import Logger
 
 import disruption_py.data
 from disruption_py.utils.utils import without_duplicates
-try:
-    import importlib.resources as importlib_resources
-except ImportError:
-    # Try backported to PY<37 `importlib_resources`.
-    import importlib_resources
+from importlib import resources
 
 
 @dataclass
@@ -69,10 +65,11 @@ class IncludedShotIdsRequest(ShotIdsRequest):
         The name of the datafile that should be used to retrieve shot_ids.
     """
     
-    def __init__(self, data_file_name):
-        with importlib_resources.path(disruption_py.data, data_file_name) as p:
-            data_file_name = str(p)
-        self.shot_ids = pd.read_csv(data_file_name, header=None).iloc[:, 0].values.tolist()
+    def __init__(self, data_file_name: str) -> List:
+        with resources.path(disruption_py.data, data_file_name) as data_file:
+            df = pd.read_csv(data_file, header=None)
+            lst = df.values[:, 0].tolist()
+            self.shot_ids = lst
     
     def _get_shot_ids(self, params : ShotIdsRequestParams) -> List:
         return self.shot_ids 

--- a/disruption_py/shots/parameter_methods/cmod/basic_parameter_methods.py
+++ b/disruption_py/shots/parameter_methods/cmod/basic_parameter_methods.py
@@ -14,11 +14,7 @@ except ImportError:
     class mdsExceptions(Exception):
         __getattr__ = lambda self, name: Exception
 
-try:
-    import importlib.resources as importlib_resources
-except ImportError:
-    # Try backported to PY<37 `importlib_resources`.
-    import importlib_resources
+from importlib import resources
 
 # TODO: Somehow link to disruption_py 
 # TODO: Deal with scary missing TRIPpy dependency (please don't break until I fix you)
@@ -563,9 +559,8 @@ class BasicCmodRequests(ShotDataRequest):
     @staticmethod
     @parameter_cached_method(columns=["v_0"], used_trees=["spectroscopy"],  tokamak=Tokamak.CMOD)
     def _get_rotation_velocity(params : ShotDataRequestParams):
-        with importlib_resources.path(
-                disruption_py.data, 'lock_mode_calib_shots.txt') as calib_path:
-            calibrated = pd.read_csv(calib_path)
+        with resources.path(disruption_py.data, "lock_mode_calib_shots.txt") as fio:
+            calibrated = pd.read_csv(fio)
         # Check to see if shot was done on a day where there was a locked
         # mode HIREX calibration by cross checking with list of calibrated
         # runs. If not calibrated, return NaN outputs.


### PR DESCRIPTION
- drop python 3.7 backport for `importlib.resources`,
- avoid unnecessary `iloc` call,
- move `read_csv` into `with` env,
- added a couple of type hints.