### PR TITLE
add Dependabot workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+---
+
+version: 2
+updates:
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    versioning-strategy: increase-if-necessary
+    schedule:
+      interval: "monthly"
+    reviewers:
+      - gtrevisan
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    reviewers:
+      - gtrevisan


### PR DESCRIPTION
add dependabot workflow on a monthly schedule for:
- `pip` packages (updated only if increase is necessary),
- GH actions.

future reference:
https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file