### PR TITLE
add Install workflow

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -43,6 +43,11 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@v1
 
+      - name: Print versions
+        run: |
+          python --version
+          poetry --version
+
       - name: Check lock files
         run: |
           poetry lock --no-update
@@ -51,3 +56,13 @@ jobs:
 
       - name: Poetry install
         run: poetry install
+
+      - name: List packages
+        run: |
+          poetry run pip list \
+          | tee pip.log
+          grep disruption.py pip.log
+
+      - name: Test import
+        run: |
+          poetry run python -c "import disruption_py"


### PR DESCRIPTION
add Install workflow to explicitly test:
- poetry lockfile is updated,
- pip lockfiles are updated,
- poetry install works.

the Tests workflows install through `pip`, not `poetry`, in order to maximize speed.