### PR TITLE
Fix computation of Z parameters

### DIFF
--- a/disruption_py/shots/parameter_methods/cmod/basic_parameter_methods.py
+++ b/disruption_py/shots/parameter_methods/cmod/basic_parameter_methods.py
@@ -318,7 +318,7 @@ class BasicCmodRequests(ShotDataRequest):
 
         """
         divsafe_ip = np.where(ip != 0, ip, np.nan)
-        z_error = z_error_without_ip/np.abs(divsafe_ip)  # [m] not sure why this never caused issues in matlab? Also no |ip| before?
+        z_error = z_error_without_ip/np.abs(divsafe_ip)  # [m]
         z_prog_dpcs = interp1(pcstime, z_prog, dpcstime)
         z_cur = z_prog_dpcs + z_error  # [m]
         v_z = np.gradient(z_cur, dpcstime)  # m/s


### PR DESCRIPTION
Made changes to basic_parameter_methods.py that fix the z_error and zcur bugs outlined in issue #133.

# Explaining the fixes

Most of the bugs appeared to be translation errors from matlab -> python, but some also appear to be errors not directly addressed in the original matlab code.

## translation errors

The issue of only returning nans is resolved by fixing the following line of code from

https://github.com/MIT-PSFC/disruption-py/blob/d96e429816f7245fb24f51780b45859da7a1837a/disruption_py/shots/parameter_methods/cmod/basic_parameter_methods.py#L391-L392

to

https://github.com/MIT-PSFC/disruption-py/blob/8bec59098e0a236ddb21b1697fe1e2bb622ac10b/disruption_py/shots/parameter_methods/cmod/basic_parameter_methods.py#L400-L401

Turns out "z_error_without_factor_and_ip" was probably mistaken for "z_error_without_ip" when translating.

In terms of other translation errors, there were also just a couple of extra -1's accedently added when interpolating zcur and z_error. See

https://github.com/MIT-PSFC/disruption-py/blob/d96e429816f7245fb24f51780b45859da7a1837a/disruption_py/shots/parameter_methods/cmod/basic_parameter_methods.py#L326-L328

These have been removed to be

https://github.com/MIT-PSFC/disruption-py/blob/8bec59098e0a236ddb21b1697fe1e2bb622ac10b/disruption_py/shots/parameter_methods/cmod/basic_parameter_methods.py#L333-L335

## intrinsic errors

The other fixes that needed to be made were not a result of miss-translation, as the original issues appear to also be written this way in the matlab code. These issues stem from the re-scaling of "z_error" from "z_error_without_ip", shown below.

https://github.com/MIT-PSFC/disruption-py/blob/d96e429816f7245fb24f51780b45859da7a1837a/disruption_py/shots/parameter_methods/cmod/basic_parameter_methods.py#L320

The issues in this line are that it doesn't account for "ip=0", which would result in "divide by 0" errors, and that it doesn't remove the sign of "ip" in the rescaling, resulting in z_error artificially switching signs.

The fix to this is shown below.

https://github.com/MIT-PSFC/disruption-py/blob/8bec59098e0a236ddb21b1697fe1e2bb622ac10b/disruption_py/shots/parameter_methods/cmod/basic_parameter_methods.py#L323-L327

# Validating the fixes

The validation for this bug fix is carried out in _examples/debug\_zcur.py_, which compares the fixed "zcur" signal to "z_prog", "lower_gap", and "upper_gap" for several relevant shots, the most notable of which probably being 1100302003 and 1160511013.

The plot below shows zcur, zprog, and z_error for shot 1100302003, which has a pre-programmed ramp up and then back down in z. The fixed zcur appears to follow the trajectory set out by zprog quite well. This shows that the zprog component of zcur (which is calculated as zcur = zprog + z_error), appears accurate.

![image](https://github.com/MIT-PSFC/disruption-py/assets/20666565/4382b1c5-6cd4-4c07-b01b-f42f5945ae51)

Finally, the plot shown below shows the same features + lower_gap and upper_gap for shot 1160511013, which has a hot VDE. In it, we see that zcur tracks the non-zero zprog well for most of the flattop, and then deviates from zprog during the VDE leading up to the disruption. The polarity of this deviation (the z_error component of zcur) is seen to be consistent with that observed by the upper/lower gaps, which increase/decrease as the plasma moves downward (as verified by the efit reconstruction). The correct polarity for the z_error component of zcur shown here suggests that removing the sign of ip in re-scaling z_error is in-fact necessary to get the right VDE direction.

![image](https://github.com/MIT-PSFC/disruption-py/assets/20666565/dc779efb-603b-41fd-b1b1-7ec072fe8827)

## acknowledgements

Thanks, Arunav, for getting me relevant non-trivial shots to look at!