### PR TITLE
Proposed zcur fix after back-and-forth with Bob

### DIFF
--- a/disruption_py/shots/parameter_methods/cmod/basic_parameter_methods.py
+++ b/disruption_py/shots/parameter_methods/cmod/basic_parameter_methods.py
@@ -318,8 +318,7 @@ class BasicCmodRequests(ShotDataRequest):
 
         """
         divsafe_ip = np.where(ip != 0, ip, np.nan)
-        z_error = z_error_without_ip/divsafe_ip  # [m]
-        z_error *= -1
+        z_error = -1*z_error_without_ip/divsafe_ip  # [m]
         z_prog_dpcs = interp1(pcstime, z_prog, dpcstime)
         z_cur = z_prog_dpcs + z_error  # [m]
         v_z = np.gradient(z_cur, dpcstime)  # m/s


### PR DESCRIPTION
# Bug fix

The original zcur fix wasn't robust to reverses in the sign of Ip, which was a result of using |Ip| in place of Ip to calculate z_error. This bug was first brought to light when Bob challenged my fix to his code, which included using |Ip|, and the true solution was discovered by applying Bob's method more appropriately, i.e. applying the sign flip to z_error BEFORE the calculation of zcur from z_error (as opposed to flipping the sign of both z_error and zcur AFTER calculating zcur from z_error), and leaving Ip with its sign.

# Validation

## -Ip case where original zcur fix has the right polarities

The original zcur fix was consistent with other physics observables for negative-Ip cases, in that it has the correct polarity for it's z_prog component and its z_error component. In contrast to this, Bob's method in the negative-Ip scenario only has the correct polarity for the z_error component, while the polarity for the z_prog component was wrong. Below shows that the upper/lower gaps and efit see the plasma moving *downward* from 1.00 [s] and on, consistent with the polarity of the z_error component of zcur in both the original zcur fix and Bob's calc. However, the upper/lower gaps, efit, and z_prog also show the plasma moving *downward* from 0.98->1.00 [s], which is only consistent with the original zcur fix's polarity (coming from its z_prog component). 

![image](https://github.com/MIT-PSFC/disruption-py/assets/20666565/e7ccc551-d429-42f6-987b-36aa29b3e1fe)
![image](https://github.com/MIT-PSFC/disruption-py/assets/20666565/afcdec44-a26e-48c4-9b68-da702bf23452)

This suggests that the original fix has the correct polarities for both its z_prog and z_error components, while Bob's calc only has the correct polarity for its z_error component. It's possible this wasn't noticed in the past because VDEs are primarily characterized with respect to the z_error component of zcur, which Bob's calc has the correct polarity for.

## +Ip case where Bob's calc has the right polarities

In contrast to the above -Ip-case, Bob's calc has the correct polarities in the +Ip-case while the original zcur fix does not. In this scenario, we see a reversal of the logic above, where now the polarity of motion observed in the upper/lower gaps and efit during the VDE is consistent with that of zcur calculated using Bob's method.

![image](https://github.com/MIT-PSFC/disruption-py/assets/20666565/7dab3c4d-b3e2-4fcc-ae1d-928269aaead5)
![image](https://github.com/MIT-PSFC/disruption-py/assets/20666565/49298d5b-380e-433c-aede-de494becb962)

This suggests that Bob's calc has the correct polarity for the z_error component of zcur, while the original zcur fix does not. Notably though, Bob's calc still doesn't get the correct polarity for the z_prog component of zcur.

## New zcur fix that's right in both -Ip and +Ip cases

With this new fix to the calculation of zcur, the polarities of the z_error and z_prog components of zcur are correct in both the -Ip and +Ip cases.

![image](https://github.com/MIT-PSFC/disruption-py/assets/20666565/91584acc-6813-4ae0-8d05-2369609fe524)
