### PR TITLE
suppress nanmean warning

### DIFF
--- a/disruption_py/shots/parameter_methods/cmod/basic_parameter_methods.py
+++ b/disruption_py/shots/parameter_methods/cmod/basic_parameter_methods.py
@@ -1265,10 +1265,9 @@ class BasicCmodRequests(ShotDataRequest):
                     core_radiation, axj_interp[axj_core_index, i]
                 )
                 all_radiation = np.append(all_radiation, axj_interp[:, i])
-            try:
+            with warnings.catch_warnings():
+                warnings.filterwarnings(action="ignore", message="Mean of empty slice")
                 prad_peaking[i] = np.nanmean(core_radiation) / np.nanmean(all_radiation)
-            except:
-                prad_peaking[i] = np.nan
         return pd.DataFrame({"prad_peaking": prad_peaking})
 
     @staticmethod


### PR DESCRIPTION
I'm not sure what that blanket `try` block was supposed to catch, so I removed it... no exceptions popped up yet, I'd probably leave it like this unless there is a glaring mistake.
both of those quantities are always defined as empty arrays in the beginning of the loop.