### PR TITLE
Add shot id argument for testing

### DIFF
--- a/tests/test_against_sql.py
+++ b/tests/test_against_sql.py
@@ -138,6 +138,7 @@ if __name__ == "__main__":
 
     parser.add_argument(
         "--shot-id",
+        type=int,
         action="store",
         default=None,
         help="Shot number to test, uses the default shot list if not specified",


### PR DESCRIPTION
## Problem
Running the Python test (not Pytest!) for `tests/test_against_sql.py` always ran the same 10 shots from the default `TEST_SHOTS` list and you could not easily run the test on a single shot. 

## Proposed Solution
Use a command-line argument to pass in a single shot id. If no shot id is provided, then the default shots will be used. 

Example usage:
```
python tests/test_against_sql.py --shot-id 1150805012
```