### PR TITLE
Remove CMOD features not in SQL DB

### DIFF
--- a/disruption_py/config.toml
+++ b/disruption_py/config.toml
@@ -134,7 +134,6 @@ TEST_COLUMNS=[
 ]
 EXPECTED_FAILURE_COLUMNS= [
 	"te_width",
-	"z_error",
 	"zcur",
 	"v_z",
 	"z_times_v_z",


### PR DESCRIPTION
Removed features:
1. z_prog
2. ip_prog
3. dip_smoothed
4. tritop
5. tribot
6. a_minor
7. rmagx
8. chisq
9. V_surf
10. n_equal_1_phase
11. BT
12. prad_peaking
13. p_input
14. commit_hash

sxr: from matlab-disruption_warning_database.m: 
2020/08/03 - RSG; Added central SXR (array_1:chord_16) to a subset of the shots in the database (only moly UFO shots).  The SXR data will be used to confirm the UFO designation.