### PR TITLE
fix trapezoid call

### DIFF
--- a/disruption_py/settings/set_times_request.py
+++ b/disruption_py/settings/set_times_request.py
@@ -268,7 +268,7 @@ class DisruptionSetTimesRequest(SetTimesRequest):
                 duration = 0
                 return duration, signal_max
         polarity = np.sign(
-            np.trapz(signal[finite_indices], signal_time[finite_indices])
+            np.trapezoid(signal[finite_indices], signal_time[finite_indices])
         )
         polarized_signal = polarity * signal
         valid_indices = np.where((polarized_signal >= threshold) & (signal_time > 0.0))

--- a/disruption_py/shots/parameter_methods/cmod/basic_parameter_methods.py
+++ b/disruption_py/shots/parameter_methods/cmod/basic_parameter_methods.py
@@ -1829,7 +1829,7 @@ class ThomsonDensityMeasure:
                 y = n_e[i, ind]
                 values_uniq, ind_uniq = np.unique(x, return_index=True)
                 y = y[ind_uniq]
-                nlts[i] = np.trapz(y, x)
+                nlts[i] = np.trapezoid(y, x)
         return nlts, nlts_t
 
     @staticmethod


### PR DESCRIPTION
in preparation of NumPy 2.0: https://numpy.org/doc/stable/numpy_2_0_migration_guide.html

> The next table presents deprecated members, which will be removed in a release after 2.0:
> deprecated member | migration guideline
> -- | --
> trapz | Use np.trapezoid or a scipy.integrate function instead.
> 