### PR TITLE
add bounds_error & fill_value settings to a_minor's interp1 call in calculating Greenwald_fraction

### DIFF
--- a/disruption_py/shots/parameter_methods/cmod/basic_parameter_methods.py
+++ b/disruption_py/shots/parameter_methods/cmod/basic_parameter_methods.py
@@ -911,7 +911,7 @@ class BasicCmodRequests(ShotDataRequest):
         dn_dt = interp1(t_n, dn_dt, times)
         ip = -ip / 1e6  # Convert from A to MA and take positive value
         ip = interp1(t_ip, ip, times)
-        a_minor = interp1(t_a, a_minor, times, bounds_error = False, fill_value = np.nan)
+        a_minor = interp1(t_a, a_minor, times, bounds_error=False, fill_value=np.nan)
         # make sure aminor is not 0 or less than 0
         a_minor[a_minor <= 0] = 0.001
         n_G = abs(ip) / (np.pi * a_minor**2) * 1e20  # Greenwald density in m ^-3


### PR DESCRIPTION
Forgot to add this in #186 