### PR TITLE
Added zmagx to efit_cols dict

### DIFF
--- a/disruption_py/shots/parameter_methods/cmod/basic_parameter_methods.py
+++ b/disruption_py/shots/parameter_methods/cmod/basic_parameter_methods.py
@@ -47,7 +47,7 @@ class CModEfitRequests(ShotDataRequest):
         "tribot": r"\efit_aeqdsk:doutl",
         "a_minor": r"\efit_aeqdsk:aminor",
         "rmagx": r"\efit_aeqdsk:rmagx",  # TODO: change units to [m] (current [cm])
-        "zmagx": r"\efit_aeqdsk:zmagx", 
+        "zmagx": r"\efit_aeqdsk:zmagx",  # TODO: change units to [m] (current [cm])
         "chisq": r"\efit_aeqdsk:chisq",
     }
 


### PR DESCRIPTION
`zmagx` is called in `_get_prad_peaking` but not included in the list of callable parameters. Useful for debugging work.