### PR TITLE
Fix prad peaking

### DIFF
--- a/disruption_py/machine/cmod/physics.py
+++ b/disruption_py/machine/cmod/physics.py
@@ -1013,7 +1013,7 @@ class CmodPhysicsMethods:
     )
     def _get_prad_peaking(params: PhysicsMethodParams):
         prad_peaking = np.full(len(params.times), np.nan)
-        nan_output = {"prad_peaking", prad_peaking}
+        nan_output = {"prad_peaking": prad_peaking}
         try:
             r0 = 0.01 * params.mds_conn.get_data(
                 r"\efit_aeqdsk:rmagx", tree_name="_efit_tree"


### PR DESCRIPTION
1. replace overbroad exception with filtered np warning,
2. fix building prad peaking nan dict.

(1) warning was:
```
RuntimeWarning: Mean of empty slice
```

(2) exception was:
```
  File "disruption-py-dev/disruption_py/core/physics_method/runner.py", line 145, in populate_method
    result = method(params=physics_method_params)
  File "disruption-py-dev/disruption_py/core/physics_method/caching.py", line 29, in wrapper
    result = method(*args, **kwargs)
  File "disruption-py-dev/disruption_py/machine/cmod/physics.py", line 1016, in _get_prad_peaking
    nan_output = {"prad_peaking", prad_peaking}
TypeError: unhashable type: 'numpy.ndarray'
```

it's disappointing that we didn't catch this sooner, using:
- black -- since this was good python syntax,
- pylint -- same as above,
- pytest -- since the column was an expected failure.

so the only way to overcome these issues is, indeed, _fully abolish overbroad exception catching_.