### PR TITLE
Rename MDSplus to fresh, SQL to cache

### DIFF
--- a/tests/utils/pytest_helper.py
+++ b/tests/utils/pytest_helper.py
@@ -23,7 +23,7 @@ def extract_param(config):
 
 
 def save_to_csv(data, module_file_path_f, data_source_name):
-    """Save a dataframe of MDSPlus or SQL data to the tmp testing directory"""
+    """Save a dataframe of fresh or cached data to the tmp testing directory"""
     for shot_id in data:
         pd.DataFrame(data[shot_id]).to_csv(
             module_file_path_f(f"-{data_source_name}-{shot_id}.csv")


### PR DESCRIPTION
## Problem
The DisruptionPy physics methods for calculating plasma parameters are written in Python but based on older Matlab codes. Our testing infrastructure, especially `tests/test_against_sql.py` , is there to ensure the Python calculations on the freshly retrieved MDSplus data match the cached SQL table populated by older Matlab code (or, if they do not match, that we know why the Python implementation is correct). 

In the tests, we refer to the Python-calculated data as MDSplus data, and the Matlab data as SQL. The difference between MDSplus data and SQL data can be confusing for new DisruptionPy users. Additionally, when we have a Python-populated SQL table, "SQL" will no longer have the same association with old, cached Matlab data which could be confusing for existing DisruptionPy users. 

## Proposed Solution
In our tests, we can rename functions and variables as follows: "sql" --> "cache" and "mds"/"mdsplus" --> "fresh". 

Benefits of the rename:
- "fresh" and "cache" describe the origin of the data in a meaningful way beyond the specific implementations
- They have the same length, which aids code readability