### PR TITLE
Fix EFIT-derived quantities

### DIFF
--- a/disruption_py/machine/cmod/efit.py
+++ b/disruption_py/machine/cmod/efit.py
@@ -93,9 +93,9 @@ class CmodEfitMethods:
                 efit_data[param] = np.full(len(efit_time), np.nan)
                 pass
 
-        for deriv_param in CmodEfitMethods.efit_derivs:
+        for deriv_param, param in CmodEfitMethods.efit_derivs.items():
             efit_data[deriv_param] = np.gradient(
-                efit_data[CmodEfitMethods.efit_derivs[deriv_param]],
+                efit_data[param],
                 efit_time,
                 edge_order=1,
             )

--- a/disruption_py/machine/d3d/efit.py
+++ b/disruption_py/machine/d3d/efit.py
@@ -59,10 +59,8 @@ class D3DEfitMethods:
         del efit_data["chisq"]
         for param in efit_data:
             efit_data[param][invalid_indices] = np.nan
-        for deriv_param in D3DEfitMethods.efit_derivs:
-            efit_data[deriv_param] = np.gradient(
-                efit_data[D3DEfitMethods.efit_derivs[deriv_param]], efit_time
-            )
+        for deriv_param, param in D3DEfitMethods.efit_derivs.items():
+            efit_data[deriv_param] = np.gradient(efit_data[param], efit_time)
         if not np.array_equal(params.times, efit_time):
             for param in efit_data:
                 efit_data[param] = interp1(efit_time, efit_data[param], params.times)


### PR DESCRIPTION
## Problem

Running `python tests/test_against_sql.py --data-column dbetap_dt` on https://github.com/MIT-PSFC/disruption-py/pull/219, which is the PR merged into dev just before [#226 Improve fetching efficiency when spot testing](https://github.com/MIT-PSFC/disruption-py/pull/226) the test passes. 

In contrast, on [`3387b51be6e394643e7f60f6180ff6e661880ede`](https://github.com/MIT-PSFC/disruption-py/pull/226), the test fails because the efit derivs are not being picked up. 

It continues to be a problem on the latest `dev` branch:`python tests/test_against_cache.py --data-column dbetap_dt`

## Proposed Solution
It seems like there was a typo of using `.keys()` instead of `.values()` in the decorator. Using `.values()` will add the efit deriv columns. 

The problem only appeared in #226 because prior to 226, all the methods were run on every test, and `_get_efit_parameters` will calculate the deriv columns even though they were not specified in the `columns` parameter of the `physics_method` decorator.

## Verification
With the changes in this PR, running the test `python tests/test_against_cache.py --data-column dbetap_dt` now succeeds like it did before single shot testing.
