### PR TITLE
Fix DIII-D get_h98 and get_h_alpha methods

### DIFF
--- a/disruption_py/machine/d3d/physics.py
+++ b/disruption_py/machine/d3d/physics.py
@@ -25,6 +25,15 @@ class D3DPhysicsMethods:
     @staticmethod
     @physics_method(columns=["h98"], tokamak=Tokamak.D3D)
     def get_h98(params: PhysicsMethodParams):
+        """
+        Get the H98y2 energy confinement time parameter
+
+        Reference
+        -------
+        https://github.com/MIT-PSFC/disruption-py/blob/matlab/DIII-D/get_H98_d3d.m
+
+        Last major update by William Wei on 7/31/2024
+        """
         output = {
             "h98": [np.nan],
         }
@@ -45,6 +54,15 @@ class D3DPhysicsMethods:
     @staticmethod
     @physics_method(columns=["h_alpha"], tokamak=Tokamak.D3D)
     def get_h_alpha(params: PhysicsMethodParams):
+        """
+        Get the H_alpha line emission intensity.
+
+        Reference
+        -------
+        https://github.com/MIT-PSFC/disruption-py/blob/matlab/DIII-D/get_H98_d3d.m
+
+        Last major update by William Wei on 7/31/2024
+        """
         output = {
             "h_alpha": [np.nan],
         }


### PR DESCRIPTION
# Description of the problem

- `h98` and `h_alpha` computations were packed  in a single `get_H_parameters()` method by mistake.
- There's also a duplicated `get_h_parameters()` method.
- Both computations used the wrong time unit (in ms instead of s), resulting to nan results after interpolation.

# Implemented fixes

- Split `get_H_parameters()` into two separate methods named `get_h98()` and `get_h_alpha()`.
- Remove the duplicated method.
- Correct the unit of time.

# Current status

- `h98` now passes the test for all 4 testing shots
- `h_alpha` passes for 161228, 161237, 166177. It also passes for the majority of time slices in 166253.