### PR TITLE
Signal caching

### DIFF
--- a/disruption_py/core/utils/misc.py
+++ b/disruption_py/core/utils/misc.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from tempfile import mkdtemp
 from typing import List
 
+import MDSplus
 import numpy as np
 import pandas as pd
 
@@ -138,6 +139,16 @@ def get_commit_hash() -> str:
     except subprocess.CalledProcessError:
         commit_hash = None
     return commit_hash
+
+
+def make_hashable(item):
+    """Create hashable objects by converting lists to tuples and MDSplus scalars
+    into NumPy scalars."""
+    if isinstance(item, (list, MDSplus.mdsarray.Int32Array)):
+        return tuple(make_hashable(e) for e in item)
+    if isinstance(item, MDSplus.mdsscalar.Int32):
+        return np.int32(item)
+    return item
 
 
 @lru_cache

--- a/disruption_py/inout/mds.py
+++ b/disruption_py/inout/mds.py
@@ -126,7 +126,7 @@ class MDSConnection:
 
     def cleanup(self):
         """
-        Close all open trees
+        Close all open trees and reset cache to save memory.
         """
         self.data_cache = None
         self.last_open_tree = None

--- a/disruption_py/inout/mds.py
+++ b/disruption_py/inout/mds.py
@@ -128,6 +128,7 @@ class MDSConnection:
         """
         Close all open trees
         """
+        self.data_cache = None
         self.last_open_tree = None
 
     @_better_mds_exceptions


### PR DESCRIPTION
## Problem
The output of the EFIT and physics methods are cached. Individual MDSplus signals are not cached, so we waste time when fetching them.

- https://github.com/MIT-PSFC/disruption-py/issues/209


## Proposed Solution
Modify the `get` methods of `mds.py` to cache their results in a dictionary. 

The key of the dictionary is a tuple of the MDS expression, the tree name, and any arguments. The value is the output of the mds call. 

## Evaluation
(Edit: add reproducible profiling example)
To verify:
Add `profile_script.py` to the disruption-py project directory:
```
#!/usr/bin/env python3

from disruption_py.settings.retrieval_settings import RetrievalSettings
from disruption_py.workflow import get_shots_data

get_shots_data(
    tokamak="cmod",
    shotlist_setting="cmod_ufo", # 122 shots
    retrieval_settings=RetrievalSettings(),
    num_processes=1,
)
```
I used https://github.com/benfred/py-spy for profiling and https://www.speedscope.app/ for viewing the profiles. 

Run it once or twice to prime the mds cache then run on both cache and dev to compare. 
On signal-caching branch: `py-spy record --rate 500 -o signal-caching.speedscope --format speedscope -- python profile_script.py`
On dev branch: `py-spy record --rate 500 -o dev.speedscope --format speedscope -- python profile_script.py`

Results:

With signal caching:
![image](https://github.com/user-attachments/assets/2cb619c6-fea1-4343-bdf9-60a42a80cc55)

Without signal caching:
![image](https://github.com/user-attachments/assets/40a0050d-f143-4ecd-b399-8f9353adb7f0)

And overall times: signal caching took 55 secs, dev took 67 secs (signal caching is 20% faster). 

