### PR TITLE
Fix get _density_parameters for DIII-D

### DIFF
--- a/disruption_py/machine/d3d/physics.py
+++ b/disruption_py/machine/d3d/physics.py
@@ -330,7 +330,7 @@ class D3DPhysicsMethods:
             a_minor = interp1(t_a, a_minor, params.times, "linear")
             with np.errstate(divide="ignore"):
                 n_g = ip / 1.0e6 / (np.pi * a_minor**2)  # [MA/m^2]
-                g_f = ne / 1.0e20 / n_g
+                g_f = ne / n_g * 1e-20
         except mdsExceptions.MdsException as e:
             # TODO: Confirm that there is a separate exception if ptdata name doesn't exist
             params.logger.info(


### PR DESCRIPTION
# Implemented changes
- Removed `fill_value="extrapolation"` in `ne` and `dne_dt` calculations which previously caused strange behaviors at the end of the shot.
- Broke up the overreaching try-except block into two separate blocks.
- Added conditional block to use `\denv2` from `d3d` tree if density data isn't available.
- Added docstring.

These changes will not resolve the XFAILs of these three parameters, as they were caused by using the different EFIT tree than the one which the SQL table was created from.

# Related issues, PRs & references
- #238 
- [get_density_parameters.m](https://github.com/MIT-PSFC/disruption-py/blob/matlab/DIII-D/get_density_parameters.m)