### PR TITLE
Fix get_rt_density_parameters methods for DIII-D

### DIFF
--- a/disruption_py/machine/d3d/physics.py
+++ b/disruption_py/machine/d3d/physics.py
@@ -321,6 +321,18 @@ class D3DPhysicsMethods:
         tokamak=Tokamak.D3D,
     )
     def get_rt_density_parameters(params: PhysicsMethodParams):
+        """
+        Get real-time electron density from EFIT, then compute the
+        real-time dn_dt and Greenwald_fraction.
+
+        References
+        -------
+        https://github.com/MIT-PSFC/disruption-py/blob/matlab/DIII-D/get_density_parameters_RT.m
+        https://github.com/MIT-PSFC/disruption-py/pull/251
+
+        Last major update by William Wei on 8/2/2024
+        """
+
         nan_output = {
             "n_e_rt": [np.nan],
             "greenwald_fraction_rt": [np.nan],


### PR DESCRIPTION
# Problem

- `greenwald_fraction_rt` failed test with data

# Implemented changes

- Fixed Greenwald_fraction computation (the real-time Ip was given in the unit of MA instead of A). Now `greenwald_fraction_rt` matches its data in the SQL table except the initial `nan` data at the beginning of a shot due to disruption-py's default interpolation behavior. It is not affected by #238 as this method does not call either `EFIT01` or the `runtag=DIS` tree.
- Added `dn_dt_rt` in the outputs.
- Did not add `dn_dt_rt` in the list of tested columns as it is unavailable in the SQL table.
- Break up overreaching try-except block.
- Added docstring.

# Remaining points to be addressed:

- [ ] Should we keep using nested try-except blocks to imitate `if (mod(status,2) == 1:` conditions in the MATLAB script?
(In #249 I used an if statement to implement a similar condition check. We can make them consistent once we decided what to do).

# References 
- https://github.com/MIT-PSFC/disruption-py/blob/matlab/DIII-D/get_density_parameters_RT.m