### PR TITLE
Fix logic for running physics methods based on tokamak parameter

### DIFF
--- a/disruption_py/core/physics_method/metadata.py
+++ b/disruption_py/core/physics_method/metadata.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
-from dataclasses import Field, dataclass, fields
-from typing import Any, Callable, List, Union
+from dataclasses import dataclass, fields
+from typing import Callable, List, Union
 
 from disruption_py.core.physics_method.params import PhysicsMethodParams
 from disruption_py.machine.tokamak import Tokamak
@@ -9,6 +9,10 @@ from disruption_py.machine.tokamak import Tokamak
 
 @dataclass(frozen=True)
 class MethodMetadata:
+    """
+    Holder for the arguments to the decorator.
+    """
+
     name: str
     populate: bool
 
@@ -42,9 +46,9 @@ class BoundMethodMetadata(MethodMetadata):
         """
         Evaluate arguments to decorators to usable values.
 
-        Some parameters provided to the physics_method decorators can take method that are evaluated
-        at runtime. `resolve_for` evaluates all of these methods and returns a new instance of `MethodMetadata`
-        without function parameters.
+        Some parameters provided to the physics_method decorators can take method
+        that are evaluated at runtime. `resolve_for` evaluates all of these methods
+        and returns a new instance of `MethodMetadata`without function parameters.
         """
         new_method_metadata_params = {}
         bind_to = (getattr(bound_method, "__self__", None),)

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import numpy as np
 import pytest
 


### PR DESCRIPTION
## Bug description
Leaving the `physics_method` `tokamak` parameter empty should mean the physics method is run for all tokamaks: https://github.com/MIT-PSFC/disruption-py/blob/40462322314d19bb11d4a54d13d8d1cdcaf30d93/disruption_py/core/physics_method/decorator.py#L34-L36

This does not happen. Instead the physics method is not run.

You can replicate it by removing one of the `tokamak` parameters in a `physics_method` decorator and see that physics method will not run.

## Proposed solution
Remove the conversion from `None` to `[]` in `metadata.py` so the check in `runner.py` works as expected:
https://github.com/MIT-PSFC/disruption-py/blob/40462322314d19bb11d4a54d13d8d1cdcaf30d93/disruption_py/core/physics_method/runner.py#L101-L103

## Verification
There is now a test for this case in `tests/test_decorator.py`. The test will fail without the changes in this branch and succeed with these changes.