### PR TITLE
Fix get_rt _ip_parameters for DIII-D

### DIFF
--- a/disruption_py/machine/d3d/physics.py
+++ b/disruption_py/machine/d3d/physics.py
@@ -9,13 +9,7 @@ from MDSplus import mdsExceptions
 from disruption_py.core.physics_method.caching import cache_method
 from disruption_py.core.physics_method.decorator import physics_method
 from disruption_py.core.physics_method.params import PhysicsMethodParams
-from disruption_py.core.utils.math import (
-    get_bolo,
-    gsastd,
-    interp1,
-    power,
-    matlab_gradient_1d_vectorized,
-)
+from disruption_py.core.utils.math import get_bolo, gsastd, interp1, power
 from disruption_py.machine.tokamak import Tokamak
 
 
@@ -488,7 +482,6 @@ class D3DPhysicsMethods:
             "ip_error_rt",
             "dip_dt_rt",
             "dipprog_dt_rt",
-            "power_supply_railed",
         ],
         tokamak=Tokamak.D3D,
     )
@@ -509,7 +502,6 @@ class D3DPhysicsMethods:
         ip_error_rt = [np.nan]
         dip_dt_rt = [np.nan]
         dipprog_dt_rt = [np.nan]
-        power_supply_railed = [np.nan]
         # Get measured plasma current parameters
         # TODO: Why open d3d and not the rt efit tree?
         try:
@@ -625,7 +617,6 @@ class D3DPhysicsMethods:
             "ip_error_rt": ip_error_rt,
             "dip_dt_rt": dip_dt_rt,
             "dipprog_dt_rt": dipprog_dt_rt,
-            "power_supply_railed": power_supply_railed,
         }
         return output
 


### PR DESCRIPTION
# Problem

- `dipprog_dt_rt` does not match the signal in the MATLAB table. This issue appears to be caused by the different behaviors between python & matlab's gradient computation.

# Implemented changes

- <s> Replaced `np.gradient` with `matlab_gradient_1d_vectorized` in `dipprog_dt_rt` calculation. This appears to address the mismatch problem for 166177 and 166253 but not completely for 161228 and 161237. </s>
- Added `ip_prog_rt` and `dip_dt_rt` in the list of outputs.
- Added docstring.
- Fix minor computation errors.

# Points to be discussed

- [x] Should we commit to using `np.gradient` in disruption-py despite the outputs don't always match exactly to the MATLAB table?
- [ ] Which is the proper tree to be called for all real-time signals? The MATLAB script does not indicate the tree name. Currently disruption-py always uses`tree_name = 'd3d'` for these signals.

https://github.com/MIT-PSFC/disruption-py/blob/5a13906aba52b22fc4119e7f867443d7936f3d03/DIII-D/get_Ip_parameters_RT.m#L57-L66
https://github.com/MIT-PSFC/disruption-py/blob/7c539c0ea6e69a701f47eb117ebb18ce1824d0c5/disruption_py/machine/d3d/physics.py#L512-L517

# Sample outputs

![image](https://github.com/user-attachments/assets/6a26eaf6-2497-4e23-a66b-6b0ee86f66aa)
![image](https://github.com/user-attachments/assets/c2372e09-1fd9-4dd3-935c-3e5fdaf4c91d)


# References
https://github.com/MIT-PSFC/disruption-py/blob/matlab/DIII-D/get_Ip_parameters_RT.m#L57-L66