### PR TITLE
Fix get_kappa_area for DIII-D

### DIFF
--- a/disruption_py/machine/d3d/physics.py
+++ b/disruption_py/machine/d3d/physics.py
@@ -1018,7 +1018,7 @@ class D3DPhysicsMethods:
         References
         -------
         https://github.com/MIT-PSFC/disruption-py/blob/matlab/DIII-D/get_kappa_area.m
-
+        https://github.com/MIT-PSFC/disruption-py/pull/256
 
         Last major update by William Wei on 8/6/2024
         """
@@ -1033,7 +1033,7 @@ class D3DPhysicsMethods:
         invalid_indices = np.where(chisq > 50)
         kappa_area[invalid_indices] = np.nan
         kappa_area = interp1(t, kappa_area, params.times)
-        return {"kappa_area": kappa_areas}
+        return {"kappa_area": kappa_area}
 
     @staticmethod
     @physics_method(


### PR DESCRIPTION
# Implemented changes
- Added `t /= 1e3` to fix the interpolation error.
- Added docstring.
- `python test_against_cache.py` will still give mismatch errors for 166177 and 166253 because of #238.

# References

- https://github.com/MIT-PSFC/disruption-py/blob/matlab/DIII-D/get_kappa_area.m