### PR TITLE
Fix get_n1rms_parameters for DIII-D

### DIFF
--- a/disruption_py/machine/d3d/physics.py
+++ b/disruption_py/machine/d3d/physics.py
@@ -741,7 +741,7 @@ class D3DPhysicsMethods:
         -------
         https://github.com/MIT-PSFC/disruption-py/blob/matlab/DIII-D/get_n1rms_d3d.m
         https://github.com/MIT-PSFC/disruption-py/pull/257
-        
+
         Last major update by William Wei on 8/6/2024
         """
         # Get n1rms signal from d3d tree


### PR DESCRIPTION
# Implemented changes

- Added `t /= 1e3` lines.
- Added try-except blocks.
- Added docstring.

# Current status

- Now `n1rms_normalized` passes `test_against_cache.py`.
- `n1rms` lacks comparison data in SQL table.