### PR TITLE
Modify get_shape_parameters for DIII-D

### DIFF
--- a/disruption_py/machine/d3d/physics.py
+++ b/disruption_py/machine/d3d/physics.py
@@ -1071,9 +1071,6 @@ class D3DPhysicsMethods:
             sqfou = params.mds_conn.get_data(
                 r"\efit_a_eqdsk:sqfou", tree_name="_efit_tree"
             )
-            aminor = params.mds_conn.get_data(
-                r"\efit_a_eqdsk:aminor", tree_name="_efit_tree"
-            )
             squareness = (sqfod + sqfou) / 2.0
             squareness = interp1(efit_time, squareness, params.times, "linear")
         except mdsExceptions.MdsException as e:
@@ -1093,7 +1090,7 @@ class D3DPhysicsMethods:
                 f"[Shot {params.shot_id}]:Failed to obtain aminor signals"
             )
             params.logger.debug(f"[Shot {params.shot_id}]:{traceback.format_exc()}")
-            squareness = [np.nan]
+            aminor = [np.nan]
         # Remove invalid indices
         try:
             chisq = params.mds_conn.get_data(


### PR DESCRIPTION
# Original status of the method

- The outputs of the method (`delta`, `squareness`, & `aminor`) failed testing with mismatched data due to #238. By pointing to the correct EFIT tree these outputs matched the corresponding signals in the SQL table.

# Implemented changes

- I restructured the function into multiple smaller try-except blocks. This way failing to fetch one of the three signals will not cause fetching and computing the other two signals from being blocked.
- Added docstring.

# References
- https://github.com/MIT-PSFC/disruption-py/blob/matlab/DIII-D/get_shape_parameters.m