### PR TITLE
MDS getMany

### DIFF
--- a/drafts/scripts/getMany/get_many_efit.py
+++ b/drafts/scripts/getMany/get_many_efit.py
@@ -1,0 +1,76 @@
+import time
+
+from matplotlib import pyplot as plt
+import numpy as np
+from tqdm import tqdm
+from disruption_py.settings.retrieval_settings import RetrievalSettings
+from disruption_py.workflow import get_shots_data
+from tests.test_cmod_writeback import assert_frame_equal_unordered
+
+
+shots = [1150805012, 1150805013, 1150805014]
+
+
+def get_efit():
+    return get_shots_data(
+        tokamak="cmod",
+        shotlist_setting=shots,
+        retrieval_settings=RetrievalSettings(
+            run_methods=["_get_EFIT_parameters"],
+            run_tags=[],
+        ),
+        output_setting="dataframe",
+        num_processes=1,
+    )
+
+
+def get_many_efit():
+    return get_shots_data(
+        tokamak="cmod",
+        shotlist_setting=shots,
+        retrieval_settings=RetrievalSettings(
+            run_methods=["_getMany_EFIT_parameters"],
+            run_tags=[],
+        ),
+        output_setting="dataframe",
+        num_processes=1,
+    )
+
+
+def get_run_times(method, num_trials):
+    times = []
+    for _ in tqdm(range(num_trials)):
+        start = time.time()
+        method()
+        end = time.time()
+        times.append(end - start)
+    return times
+
+
+result = get_many_efit()
+print("Num efit quantities:", len(result.columns))
+assert_frame_equal_unordered(get_many_efit(), get_efit())
+
+
+NUM_TRIALS = 100
+
+many_avgs = []
+orig_avgs = []
+orig = get_run_times(get_efit, NUM_TRIALS)
+many = get_run_times(get_many_efit, NUM_TRIALS)
+
+orig = np.array(orig) * 1000
+many = np.array(many) * 1000
+
+plt.title(f"MDS getMany vs get for efit requests, {NUM_TRIALS} trials")
+plt.hist(orig, label="get", alpha=0.7)
+plt.hist(many, label="getMany", alpha=0.7)
+
+orig_mean, many_mean = np.mean(orig), np.mean(many)
+plt.axvline(orig_mean, linestyle="--", color="C0", label=f"$\mu={orig_mean: .2f}$ ms")
+plt.axvline(many_mean, linestyle="--", color="C1", label=f"$\mu={many_mean: .2f}$ ms")
+plt.xlabel("Time to get efit data (ms)")
+plt.ylabel("Frequency")
+plt.legend()
+plt.tight_layout()
+plt.savefig("efit_many.png")

--- a/drafts/scripts/getMany/get_many_efit.py
+++ b/drafts/scripts/getMany/get_many_efit.py
@@ -48,7 +48,6 @@ def get_run_times(method, num_trials):
 
 
 result = get_many_efit()
-print("Num efit quantities:", len(result.columns))
 assert_frame_equal_unordered(get_many_efit(), get_efit())
 
 
@@ -62,7 +61,7 @@ many = get_run_times(get_many_efit, NUM_TRIALS)
 orig = np.array(orig) * 1000
 many = np.array(many) * 1000
 
-plt.title(f"MDS getMany vs get for efit requests, {NUM_TRIALS} trials")
+plt.title(f"MDS getMany vs get for efit requests, {NUM_TRIALS} trials, 22 quantities")
 plt.hist(orig, label="get", alpha=0.7)
 plt.hist(many, label="getMany", alpha=0.7)
 

--- a/drafts/scripts/getMany/get_many_z_factor.py
+++ b/drafts/scripts/getMany/get_many_z_factor.py
@@ -66,4 +66,27 @@ plt.xlabel("Number of MDSplus requests")
 plt.ylabel("Time (ms)")
 plt.legend()
 plt.savefig("z_factor_many.png")
-plt.show()
+plt.cla()
+
+
+### Histogram
+# Compare the same number of z_factor and efit requests
+NUM_EFIT_REQS = 22
+NUM_TRIALS = 100
+orig = get_run_times(z_factor, NUM_TRIALS, NUM_EFIT_REQS)
+many = get_run_times(z_factor_MANY, NUM_TRIALS, NUM_EFIT_REQS)
+many = np.array(many) * 1000
+orig = np.array(orig) * 1000
+orig_mean, many_mean = np.mean(orig), np.mean(many)
+plt.title(
+    f"MDS getMany vs get for {NUM_EFIT_REQS} z_factor requests, {NUM_TRIALS} trials"
+)
+plt.hist(orig, label="get", alpha=0.7)
+plt.hist(many, label="getMany", alpha=0.7)
+plt.axvline(orig_mean, linestyle="--", color="C0", label=f"$\mu={orig_mean: .2f}$ ms")
+plt.axvline(many_mean, linestyle="--", color="C1", label=f"$\mu={many_mean: .2f}$ ms")
+plt.xlabel("Time to get efit data (ms)")
+plt.ylabel("Frequency")
+plt.legend()
+plt.tight_layout()
+plt.savefig("z_factor_many_hist.png")

--- a/drafts/scripts/getMany/get_many_z_factor.py
+++ b/drafts/scripts/getMany/get_many_z_factor.py
@@ -1,0 +1,69 @@
+import time
+
+import numpy as np
+from tqdm import tqdm
+from matplotlib import pyplot as plt
+
+from disruption_py.inout.mds import ProcessMDSConnection
+from disruption_py.machine.tokamak import resolve_tokamak_from_environment
+
+tokamak = resolve_tokamak_from_environment("cmod")
+
+NUM_ACTIVE_WIRE_SEGMENTS = 2
+Z_WIRE_INDEX = 2
+
+
+def z_factor(mds, num_mds_requests):
+    for i in range(num_mds_requests):
+        mds.get_data(
+            rf"\dpcs::top.seg_{i % NUM_ACTIVE_WIRE_SEGMENTS + 1:02d}:p_{Z_WIRE_INDEX:02d}:predictor:factor",
+            tree_name="hybrid",
+        )
+
+
+def z_factor_MANY(mds, num_mds_requests):
+    names = []
+    expressions = []
+    for i in range(num_mds_requests):
+        names.append(str(i))
+        expressions.append(
+            rf"\dpcs::top.seg_{i % NUM_ACTIVE_WIRE_SEGMENTS + 1:02d}:p_{Z_WIRE_INDEX:02d}:predictor:factor"
+        )
+    mds.get_many(names=names, expressions=expressions, tree_name="hybrid")
+
+
+def get_run_times(method, num_trials, num_mds_requests):
+    mds = ProcessMDSConnection.from_config(tokamak).get_shot_connection(1150805012)
+
+    times = []
+    for _ in range(num_trials):
+        start = time.time()
+        method(mds, num_mds_requests)
+        end = time.time()
+        times.append(end - start)
+    return times
+
+
+NUM_TRIALS = 10
+
+many_avgs = []
+orig_avgs = []
+num_mds_requests = np.arange(10, 300, 10)
+for num_req in tqdm(num_mds_requests):
+    orig = get_run_times(z_factor, NUM_TRIALS, num_req)
+    many = get_run_times(z_factor_MANY, NUM_TRIALS, num_req)
+
+    many = np.array(many) * 1000
+    orig = np.array(orig) * 1000
+
+    many_avgs.append(np.mean(many))
+    orig_avgs.append(np.mean(orig))
+
+plt.title(f"MDS getMany vs get for different number of z_factors, {NUM_TRIALS} trials")
+plt.scatter(num_mds_requests, many_avgs, label="getMany")
+plt.scatter(num_mds_requests, orig_avgs, label="get")
+plt.xlabel("Number of MDSplus requests")
+plt.ylabel("Time (ms)")
+plt.legend()
+plt.savefig("z_factor_many.png")
+plt.show()


### PR DESCRIPTION
## [DRAFT INVESTIGATION]
Greg gave a good suggestion of comparing efit methods using `get` vs `getMany` in addition to the comparison of z_factors here:
- https://github.com/MIT-PSFC/disruption-py/issues/253

This branch holds the code to make the plot below and in the above issue. 

The plot below shows the distribution of times of running the efit method. The efit methods needs to get 22 different quantities from MDS and perform interpolations, gradients, and other calculations in addition to fetching data.
![efit](https://github.com/user-attachments/assets/05068524-8920-423e-b0ae-73408d756be4)

For comparison, the plot below shows the distribution of times to only fetch (no computations) 22 z_factors (repeatedly getting the same two quantities)
![zfactor](https://github.com/user-attachments/assets/459ba193-df3b-4872-a1a1-66c25dfacc21)

## Physics Method MDSplus `get` calls
### C-Mod
Here's the breakdown of C-Mod physics methods and the number of MDSplus calls they make (each call to get_data_with_dims  is actually 2 mdsplus calls) for shot 1150805012:

All have at least 1 call to get_data to get the time. 

**My takeaway**: a naive parallelization of _get_ip_parameters and _get_z_parameters would result in a lot of extraneous data fetching, but if we have an alternate way to find a particular wire_node_name (we need ZCUR in _get_z_parameters and IP in _get_ip_parameters) then parallelization would make sense because the rest of the methods that don't depend on ip or z can be easily parallelized.

physics_method | get | get_data | get_data_with_dims | total | notes
-- | -- | -- | -- | -- | --
get_active_wire_segments |   |   |   |   | Not a physics method, but called in both ip and z param methods. Some mds calls are conditioned on the output of previous ones, tho [jas-optional-cache](https://github.com/MIT-PSFC/disruption-py/compare/jas-optional-cache?diff=unified&w=#diff-737b2664fdb8001b5c706f0fc89a2a3ec97367ce467583ed8fa957ce826d40c4R158-R164) removed that logic, so the conditioning might not be necessary
_get_time_until_disrupt | 0 | 1 | 0 | 1 | Easy
_get_ip_parameters | 3 | 11 | 2 | 18 | Loops through 16 wire indices to find one with Ip. If all these checks are necessary and we parallelize everything, then we could be doing a (worst case) extra 30 get_data and 15 get_data_with_dims calls
_get_z_parameters | 3 | 17 | 3 | 26 | Like _get_ip_parameters, loops thru 16 wire segments, so parallelizing the first part requires extra mdsplus calls.
_get_ohmic_parameters | 3 | 11 | 4 | 22 | Two get_data_with_dims can be easily combined, but the remaining calls are from _get_ip_parameters
_get_power | 3 | 11 | 7 | 28 | Three get_data_with_dims can be easily combined, and the remaining calls are from _get_ohmic_parameters
_get_kappa_area | 0 | 4 | 0 | 4 | Easy
_get_rotation_velocity | 0 | 1 | 0 | 1 | Easy
_get_n_equal_1_amplitude | 0 | 8 | 1 | 10 | Easy
_get_densities | 0 | 1 | 3 | 7 | Easy
_get_efc_current | 0 | 1 | 1 | 3 | Easy
_get_Ts_parameters | 0 | 2 | 1 | 4 | Easy
_get_peaking_factors | 0 | 6 | 2 | 10 | Easy
_get_prad_peaking | 0 | 7 | 3 | 13 | Easy
_get_sxr_data | 0 | 1 | 1 | 3 | Easy

### DIII-D
DIII-D Physics methods seem much easier to parallelize (based on shot 161228): 

physics_method | get | get_data | get_data_with_dims | get_dims | total | notes
-- | -- | -- | -- | -- | -- | --
_get_time_until_disrupt | 0 | 0 | 1 | 0 | 2 | Easy
get_h98 | 0 | 0 | 2 | 0 | 4 | Easy
get_h_alpha | 0 | 0 | 2 | 0 | 4 | Easy
get_power_parameters | 0 | 0 | 5 | 0 | 10 | Easy
get_ohmic_parameters | 0 | 0 | 3 | 0 | 6 | Easy
get_density_parameters | 0 | 0 | 4 | 0 | 8 | Easy
get_rt_density_parameters | 0 | 0 | 4 | 0 | 8 | Easy
get_ip_parameters | 0 | 1 | 5 | 0 | 11 | Easy
get_rt_ip_parameters | 0 | 1 | 6 | 0 | 13 | Easy
get_z_parameters | 0 | 1 | 6 | 0 | 13 | Easy
get_n1_bradial_parameters | 0 | 0 | 3 | 0 | 6 | There's a strange comment about shots missing bradial calculations. If we parallelize, there might be one extra call that we need to do because both onsbradial and dusbradial are checked for the same quantity.
get_n1rms_parameters | 0 | 0 | 3 | 0 | 6 | Easy
get_peaking_factors | 0 | 7 | 51 | 1 | 110 | Should be parallizable, though it calls _get_ne_te which has a few conditionals. However, I think only one path down the conditionals is used because data_source="blessed" is never changed
get_zeff_parameters | 0 | 0 | 2 | 0 | 4 | Easy
get_kappa_area | 1 | 3 | 1 | 0 | 6 | Easy
get_shape_parameters | 0 | 7 | 1 | 0 | 9 | Easy