### PR TITLE
Implement ne & pressure peaking factors for C-MOD

### DIFF
--- a/disruption_py/machine/cmod/physics.py
+++ b/disruption_py/machine/cmod/physics.py
@@ -14,7 +14,7 @@ from disruption_py.core.physics_method.decorator import physics_method
 from disruption_py.core.physics_method.params import PhysicsMethodParams
 from disruption_py.core.utils.math import gaussian_fit, interp1, smooth
 from disruption_py.machine.tokamak import Tokamak
-from disruption_py.machine.cmod.thomson import ThomsonDensityMeasure
+from disruption_py.machine.cmod.thomson import CmodThomsonDensityMeasure
 
 warnings.filterwarnings("error", category=RuntimeWarning)
 
@@ -1036,7 +1036,7 @@ class CmodPhysicsMethods:
             # This shouldn't affect ne_PF (except if calib is not between 0.5 & 1.5)
             # because we're just multiplying ne by a constant
             (nl_ts1, nl_ts2, nl_tci1, nl_tci2, _, _) = (
-                ThomsonDensityMeasure.compare_ts_tci(params)
+                CmodThomsonDensityMeasure.compare_ts_tci(params)
             )
             if np.mean(nl_ts1) != 1e32 and np.mean(nl_ts2) != 1e32:
                 nl_tci = np.concatenate((nl_tci1, nl_tci2))

--- a/disruption_py/machine/cmod/thomson.py
+++ b/disruption_py/machine/cmod/thomson.py
@@ -11,7 +11,7 @@ from disruption_py.machine.cmod import CmodEfitMethods
 
 
 # helper class holding functions for thomson density measures
-class ThomsonDensityMeasure:
+class CmodThomsonDensityMeasure:
 
     # The following methods are translated from IDL code.
     @staticmethod
@@ -33,10 +33,10 @@ class ThomsonDensityMeasure:
         tci, tci_t = params.mds_conn.get_data_with_dims(
             f".TCI.RESULTS:NL_{nlnum:02d}", tree_name="electrons"
         )
-        nlts, nlts_t = ThomsonDensityMeasure.integrate_ts_tci(params, nlnum)
+        nlts, nlts_t = CmodThomsonDensityMeasure.integrate_ts_tci(params, nlnum)
         t0 = np.amin(nlts_t)
         t1 = np.amax(nlts_t)
-        nyag1, nyag2, indices1, indices2 = ThomsonDensityMeasure.parse_yags(params)
+        nyag1, nyag2, indices1, indices2 = CmodThomsonDensityMeasure.parse_yags(params)
         time1, time2 = -1, -1
         if nyag1 > 0:
             ts_time1 = tci_time[indices1]
@@ -107,7 +107,7 @@ class ThomsonDensityMeasure:
         edge_mult = 1.0
         nlts = 1e32
         nlts_t = 1e32
-        t, z, n_e, n_e_sig = ThomsonDensityMeasure.map_ts2tci(params, nlnum)
+        t, z, n_e, n_e_sig = CmodThomsonDensityMeasure.map_ts2tci(params, nlnum)
         if z[0, 0] == 1e32:
             return None, None  # TODO: Log and maybe return nan arrs
         nts = len(t)
@@ -189,11 +189,11 @@ class ThomsonDensityMeasure:
         nets_core_t = nets_core_t[valid_indices]
         nets = nets[valid_indices]
         nets_err = nets_err[valid_indices]
-        psits = ThomsonDensityMeasure.efit_rz2psi(params, rts, zts, nets_core_t)
+        psits = CmodThomsonDensityMeasure.efit_rz2psi(params, rts, zts, nets_core_t)
         mtci = 101
         ztci = -0.4 + 0.8 * np.arange(0, mtci) / (mtci - 1)
         rtci = rtci[nlnum] + np.zeros((1, mtci))
-        psitci = ThomsonDensityMeasure.efit_rz2psi(params, rtci, ztci, nets_core_t)
+        psitci = CmodThomsonDensityMeasure.efit_rz2psi(params, rtci, ztci, nets_core_t)
         psia = interp1(psia_t, psia, nets_core_t)
         psi_0 = interp1(psia_t, psi_0, nets_core_t)
         nts = len(nets_core_t)


### PR DESCRIPTION
# Summary of changes
- Implemented ne & pressure peaking factors computations in `CmodPhysicsMethods.get_peaking_factors`.
- Restored `ThomsonDensityMeasure` functions to a workable state.
- Implemented ne calibration through comparing TS & TCI in `_get_peaking_factors`
- Added a `USE_TS_TCI_CALIBRATION = False` flag to prevent running TS-TCI calibration as it runs really slowly.

# TS-TCI calibration

- These functions compare the density measurements from TS & the two-color interferometer (TCI). If the ratio (`calib = mean(tci) / mean(ts)` which is a number not an array) is between 0.5 and 1.5 then we scales all `ne` measurements by `calib`; otherwise the function returns nans.
- As the ne measurements are scaled by a constant, the resulted peaking factor does not change unless `calib` is under 0.5 or over 1.5.
- I have not verified the calibration functions (`ThomsonDensityMeasure` class) and the TCI signals in details so I'm not confident whether these functions are giving reliable results.

# Testing status

- `ne_peaking` and `pressure_peaking` pass all tests except `1150805015` at the end of the ramp down similar to [what's found previously](https://github.com/MIT-PSFC/disruption-py/issues/210#issuecomment-2229022033).