### PR TITLE
Fix docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,14 +45,14 @@ nav:
       - Calculated Parameters:
           - Physics Methods:
               - Overview: usage/physics_methods/physics_method_reference.md
-              - C-Mod Built-in Methods: >
-                  usage/physics_methods/cmod_built_in_method_reference.md
-              - D3D Built-in Methods: >
-                  usage/physics_methods/d3d_built_in_method_reference.md
-              - Physics Method Decorators: >
-                  usage/physics_methods/decorator_reference.md
-          - Parameter Reference: >
-              usage/physics_methods/disruption_parameters_reference.md
+              - C-Mod Built-in Methods: "usage/physics_methods/\
+                cmod_built_in_method_reference.md"
+              - D3D Built-in Methods: "usage/physics_methods/\
+                d3d_built_in_method_reference.md"
+              - Physics Method Decorators: "usage/physics_methods/\
+                decorator_reference.md"
+          - Parameter Reference: "usage/physics_methods/\
+            disruption_parameters_reference.md"
       - Data I/O:
           - SQL Database: usage/sql_database.md
           - MDSplus Connection: usage/mds_connection_reference.md


### PR DESCRIPTION
## Problem
https://mit-psfc.github.io/disruption-py/usage/physics_methods/cmod_built_in_method_reference.md and the other physics method docs give 404 error because the long lines in yaml were not split properly.

## Solution
Use broken up strings instead of >