### PR TITLE
change dependabot target to dev

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,7 @@ updates:
 
   - package-ecosystem: "pip"
     directory: "/"
+    target-branch: "dev"
     versioning-strategy: increase-if-necessary
     schedule:
       interval: "monthly"


### PR DESCRIPTION
change Dependabot target branch to `dev`, rather than `main`, so that its PRs can easily be considered and merged.