### PR TITLE
Fix cyclic-import

### DIFF
--- a/disruption_py/machine/cmod/thomson.py
+++ b/disruption_py/machine/cmod/thomson.py
@@ -7,7 +7,7 @@ from MDSplus import mdsExceptions
 from disruption_py.core.physics_method.params import PhysicsMethodParams
 from disruption_py.core.utils.math import interp1
 from disruption_py.core.utils.misc import safe_cast
-from disruption_py.machine.cmod import CmodEfitMethods
+from disruption_py.machine.cmod.efit import CmodEfitMethods
 
 
 # helper class holding functions for thomson density measures


### PR DESCRIPTION
fix:
- R0401 @ https://pylint.pycqa.org/en/latest/user_guide/messages/refactor/cyclic-import.html

by importing from the lower level C-MOD module, not the parent module.