### PR TITLE
Fix pytest argument parsing

### DIFF
--- a/tests/utils/pytest_helper.py
+++ b/tests/utils/pytest_helper.py
@@ -18,6 +18,8 @@ def extract_param(config):
         List[str], the data column if it exists, otherwise None.
     """
     args = config.invocation_params.args
+    if len(args) == 0:
+        return None
     m = re.search(r"\[(.+)\]$", args[-1])
     param = [m.group(1)] if m is not None else None
     return param


### PR DESCRIPTION
## Problem
Running `pytest` without any extra arguments (ie not running `pytest tests` or `pytest tests/test_against_cache`) caused all of the test_against_cache tests to fail with e.g.
`ERROR tests/test_against_cache.py::test_data_columns[i_efc] - IndexError: tuple index out of range`

## Proposed solution
Check if there are no arguments when extracting the column name.

## Verification
Running `pytest` without any args should now work as expected. 