### PR TITLE
Add stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,21 @@
+---
+
+name: Stale
+
+# yamllint disable-line rule:truthy
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-stale: 90
+          days-before-close: 15


### PR DESCRIPTION
allow me to propose to:
1. label issues and pull requests as _stale_ after 3 months of inactivity,
2. **close** issues and pull requests after another 2 weeks of inactivity.

it's a lax requirement as stuff won't be closed if somebody comments anything on the issue or PR. :spider_web: 