### PR TITLE
Fix unused keyword arguments

### DIFF
--- a/disruption_py/core/retrieval_manager.py
+++ b/disruption_py/core/retrieval_manager.py
@@ -178,7 +178,7 @@ class RetrievalManager:
         self,
         physics_method_params: PhysicsMethodParams,
         retrieval_settings: RetrievalSettings,
-        **kwargs,
+        **_kwargs,
     ) -> PhysicsMethodParams:
 
         new_timebase = retrieval_settings.domain_setting.get_domain(

--- a/disruption_py/core/utils/math.py
+++ b/disruption_py/core/utils/math.py
@@ -1031,7 +1031,7 @@ def matlab_get_bolo(shot_id, bol_channels, bol_prm, bol_top, bol_time, drtau=50)
     return bolo_shot
 
 
-def matlab_gradient_1d_vectorized(f, h, **kwargs):
+def matlab_gradient_1d_vectorized(f, h, **_kwargs):
     """
     Compute the gradient for a 1D array using vectorized operations.
 

--- a/disruption_py/inout/sql.py
+++ b/disruption_py/inout/sql.py
@@ -34,7 +34,7 @@ class ShotDatabase:
         passwd,
         protected_columns=None,
         write_database_table_name=None,
-        **kwargs,
+        **_kwargs,
     ):
 
         if protected_columns is None:
@@ -497,7 +497,7 @@ class DummyDatabase(ShotDatabase):
         pass
 
     @classmethod
-    def initializer(cls, **kwargs):
+    def initializer(cls, **_kwargs):
         return cls()
 
     @property
@@ -505,19 +505,19 @@ class DummyDatabase(ShotDatabase):
         return DummyObject()
 
     # pylint: disable-next=arguments-differ
-    def query(self, **kwargs):
+    def query(self, **_kwargs):
         return pd.DataFrame()
 
     # pylint: disable-next=arguments-differ
-    def get_shots_data(self, **kwargs):
+    def get_shots_data(self, **_kwargs):
         return pd.DataFrame()
 
     # pylint: disable-next=arguments-differ
-    def get_disruption_time(self, **kwargs):
+    def get_disruption_time(self, **_kwargs):
         return None
 
-    def get_disruption_shotlist(self, **kwargs):
+    def get_disruption_shotlist(self, **_kwargs):
         return []
 
-    def get_disruption_warning_shotlist(self, **kwargs):
+    def get_disruption_warning_shotlist(self, **_kwargs):
         return []

--- a/examples/custom_physics_method.py
+++ b/examples/custom_physics_method.py
@@ -29,6 +29,7 @@ def decorated_physics_method(params: PhysicsMethodParams) -> dict:
         parameter being a key-value pair. Each of the dictionary's values should be the same
         length as the timebase (`params.times`).
     """
+    _ = params
 
 
 # # Paramater cached method example


### PR DESCRIPTION
fix:
- W0613 @ https://pylint.pycqa.org/en/latest/user_guide/messages/warning/unused-argument.html

by adopting the often-suggested strategy of renaming any unused `kwargs` parameter and adding a leading underscore.