### PR TITLE
Add build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,10 +51,10 @@ jobs:
         run: poetry run python -c "import disruption_py"
 
       - name: Build package
-        run: poetry run build
+        run: poetry build
 
       - name: Publish package
         if: github.event_name == 'release'
         env:
           POETRY_PYPI_TOKEN_PYPI: "${{ secrets.PYPI_TOKEN }}"
-        run: poetry run publish
+        run: poetry publish


### PR DESCRIPTION
revamp the Install workflow to become a Build workflow.
current logic is running for:
- commits on `main` and `dev`,
- PRs on `main`,
- new releases.

The action should publish to PyPI only when triggered by a release.
still, I thought it remains useful to test:
- poetry check
- poetry build
- poetry install

even for commits, so that we double check that no change in the code made the package impossible to build, either by creating an impossible-to-be-solved dependency checkmate (eg someone modifying project deps by hand), or by minor bugs (eg someone renaming the README.md and poetry failing to find it).

it could be simplified in case this build/build workflow wasn't adding anything to the other CI/CD tests.
any suggestion is appreciated!