### PR TITLE
Rename step for building docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,7 +25,7 @@ concurrency:
 
 jobs:
 
-  build:
+  docs:
     runs-on: ubuntu-latest
     if: |
       github.event_name == 'push' ||

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -61,7 +61,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
-    needs: build
+    needs: docs
     steps:
       - name: Deploy to GitHub Pages
         id: deployment


### PR DESCRIPTION
rename the step which builds the documentation from `build` to `docs`, so as to be able to request its presence and success before merging PRs -- previously `Docs/build` clashed with `Build/build` and the Github branch protection rules did not seem to distinguish between the two.