### PR TITLE
Fix stale bot

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -24,3 +24,6 @@ jobs:
             This issue has been open for 3 months with no activity.
           stale-pr-message: >
             This pull request has been open for 6 months with no activity.
+          stale-issue-label: stale
+          exempt-issue-labels: eternal
+          exempt-pr-labels: eternal

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -17,13 +17,12 @@ jobs:
     steps:
       - uses: actions/stale@v9
         with:
-          days-before-issue-stale: 90
-          days-before-pr-stale: 180
+          days-before-stale: 90
           days-before-close: 30
           stale-issue-message: >
             This issue has been open for 3 months with no activity.
           stale-pr-message: >
-            This pull request has been open for 6 months with no activity.
+            This pull request has been open for 3 months with no activity.
           stale-issue-label: stale
           exempt-issue-labels: eternal
           exempt-pr-labels: eternal

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -17,5 +17,10 @@ jobs:
     steps:
       - uses: actions/stale@v9
         with:
-          days-before-stale: 90
-          days-before-close: 15
+          days-before-issue-stale: 90
+          days-before-pr-stale: 180
+          days-before-close: 30
+          stale-issue-message: >
+            This issue has been open for 3 months with no activity.
+          stale-pr-message: >
+            This pull request has been open for 6 months with no activity.

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -5,7 +5,7 @@ name: Stale
 # yamllint disable-line rule:truthy
 on:
   schedule:
-    - cron: '30 1 * * *'
+    - cron: '30 1 * * MON-FRI'
 
 permissions:
   issues: write


### PR DESCRIPTION
- add messages to stale bot so that notifications are actually sent out,
- allow longer times before action,
- only run during weekdays,
- create new "eternal" label to exclude.

reference:
- https://github.com/actions/stale/?tab=readme-ov-file#all-options