### PR TITLE
Compute beta normalized for both old and new C-MOD shots

### DIFF
--- a/disruption_py/machine/cmod/efit.py
+++ b/disruption_py/machine/cmod/efit.py
@@ -114,7 +114,7 @@ class CmodEfitMethods:
             print("unable to get V_surf")
             efit_data["v_surf"] = np.full(len(efit_time), np.nan)
 
-        # For shots before 2000, compute beta_n and v_loop
+        # For shots before 2000, compute v_loop
         if params.shot_id <= 1000000000:
 
             # Get data for v_loop --> deriv(\ANALYSIS::EFIT_SSIMAG)*$2pi (not totally

--- a/disruption_py/machine/cmod/efit.py
+++ b/disruption_py/machine/cmod/efit.py
@@ -30,7 +30,6 @@ class CmodEfitMethods:
     """
 
     efit_cols = {
-        "beta_n": r"\efit_aeqdsk:betan",
         "beta_p": r"\efit_aeqdsk:betap",
         "kappa": r"\efit_aeqdsk:eout",
         "li": r"\efit_aeqdsk:ali",
@@ -59,7 +58,6 @@ class CmodEfitMethods:
             *efit_derivs.keys(),
             "v_surf",
             "v_loop_efit",
-            "beta_n",
         ],
         tokamak=Tokamak.CMOD,
     )
@@ -129,14 +127,6 @@ class CmodEfitMethods:
             except mdsExceptions.MdsException:
                 print("unable to get v_loop_efit")
                 efit_data["v_loop_efit"] = np.full(len(efit_time), np.nan)
-
-            # Compute beta_n
-            beta_t = params.mds_conn.get_data(
-                r"\efit_aeqdsk:betat", tree_name="_efit_tree", astype="float64"
-            )  # [dimensionless]
-            efit_data["beta_n"] = np.reciprocal(
-                np.reciprocal(beta_t) + np.reciprocal(efit_data["beta_p"])
-            )
 
         if not np.array_equal(params.times, efit_time):
             for param in efit_data:

--- a/disruption_py/machine/cmod/physics.py
+++ b/disruption_py/machine/cmod/physics.py
@@ -1768,9 +1768,9 @@ class CmodPhysicsMethods:
 
         Since the total beta is dominated by the toroidal beta
         (1/beta_tot = 1/beta_tor + 1/beta_pol), we approximate beta_n using
-        beta_t. This definition is consistent with that of \efit_aeqdsk:betan
+        beta_t. This definition is consistent with that of efit_aeqdsk:betan
         which isn't available for pre-2000 shots. For the same reason we use
-        \cpasma and \btaxp from AEQDSK instead of \ip and \btor from \magnetics
+        cpasma and btaxp from AEQDSK instead of ip and btor from magnetics
         for the plasma current and toroidal field data.
 
         Parameters

--- a/disruption_py/machine/cmod/physics.py
+++ b/disruption_py/machine/cmod/physics.py
@@ -1756,7 +1756,7 @@ class CmodPhysicsMethods:
 
     @staticmethod
     @physics_method(
-        columns=["beta_n_calc"],
+        columns=["beta_n"],
         tokamak=Tokamak.CMOD,
     )
     def get_beta_normalized(params: PhysicsMethodParams):
@@ -1806,11 +1806,11 @@ class CmodPhysicsMethods:
         with np.errstate(divide="ignore", invalid="ignore"):
             ip_normalized = ip / (aminor * btor)
             beta_n = beta_t / ip_normalized
-            
+
         # Interpolate beta_n to params.times
         beta_n = interp1(efittime, beta_n, params.times)
 
-        return {"beta_n_calc": beta_n}
+        return {"beta_n": beta_n}
 
     @staticmethod
     def is_on_blacklist(shot_id: int) -> bool:

--- a/disruption_py/machine/cmod/physics.py
+++ b/disruption_py/machine/cmod/physics.py
@@ -1782,7 +1782,8 @@ class CmodPhysicsMethods:
 
         Returns
         -------
-        beta_n: the normalized beta given in percentage.
+        dict
+            A dictionary containing the beta_n data given in percentage.
 
         References
         ----------

--- a/disruption_py/machine/cmod/physics.py
+++ b/disruption_py/machine/cmod/physics.py
@@ -1801,7 +1801,7 @@ class CmodPhysicsMethods:
         btor = params.mds_conn.get_data(
             r"\efit_aeqdsk:btaxp", tree_name="_efit_tree", astype="float64"
         )  # [T]
-
+        
         # Calculate beta_n
         with np.errstate(divide="ignore", invalid="ignore"):
             ip_normalized = ip / (aminor * btor)

--- a/disruption_py/machine/cmod/physics.py
+++ b/disruption_py/machine/cmod/physics.py
@@ -1755,10 +1755,7 @@ class CmodPhysicsMethods:
         return {"sxr": sxr}
 
     @staticmethod
-    @physics_method(
-        columns=["beta_n"],
-        tokamak=Tokamak.CMOD,
-    )
+    @physics_method(columns=["beta_n"], tokamak=Tokamak.CMOD)
     def get_beta_normalized(params: PhysicsMethodParams):
         """
         Calculate the normalized beta (beta_n) also known as the Troyon factor.

--- a/disruption_py/machine/cmod/physics.py
+++ b/disruption_py/machine/cmod/physics.py
@@ -1801,7 +1801,7 @@ class CmodPhysicsMethods:
         btor = params.mds_conn.get_data(
             r"\efit_aeqdsk:btaxp", tree_name="_efit_tree", astype="float64"
         )  # [T]
-        
+
         # Calculate beta_n
         with np.errstate(divide="ignore", invalid="ignore"):
             ip_normalized = ip / (aminor * btor)

--- a/disruption_py/machine/cmod/physics.py
+++ b/disruption_py/machine/cmod/physics.py
@@ -1767,11 +1767,13 @@ class CmodPhysicsMethods:
         divided by Ip [MA]/(a*Bt).
 
         Since the total beta is dominated by the toroidal beta
-        (1/beta_tot = 1/beta_tor + 1/beta_pol), we approximate beta_n using
-        beta_t. This definition is consistent with that of efit_aeqdsk:betan
-        which isn't available for pre-2000 shots. For the same reason we use
-        cpasma and btaxp from AEQDSK instead of ip and btor from magnetics
-        for the plasma current and toroidal field data.
+        (1/beta_tot = 1/beta_tor + 1/beta_pol), we can approximate beta_n
+        using beta_t. This definition is consistent with that of
+        EFIT_AEQDSK:BETAN which isn't available for pre-2000 shots.
+
+        To make the input data consistent with EFIT_AEQDSK:BETAN, we use
+        CPASMA and BTAXP from EFIT_AEQDSK instead of IP and BTOR from MAGNETICS
+        for Ip and Bt.
 
         Parameters
         ----------

--- a/examples/efit.py
+++ b/examples/efit.py
@@ -22,7 +22,7 @@ def main():
         shape = (247, 17)
     elif tokamak is Tokamak.CMOD:
         shotlist = [1150805012]
-        shape = (62, 25)
+        shape = (62, 24)
     else:
         raise ValueError(f"Unspecified or unsupported tokamak: {tokamak}.")
 


### PR DESCRIPTION
# Original problems

- `\efit_aeqdsk:betan` is undefined for pre-2000 shots.
- There's a separate `betan` computation in `cmod/efit.py` for pre-2000 shots written by someone, but the calculation is wrong.

# Implemented changes

- Adding `get_beta_normalized` function in `cmod/physics.py`. This method takes in beta_t, ip, aminor, & btor data from EFIT and computes beta_n using the same formulation as `\efit_aeqdsk:betan`. The output agrees with `\efit_aeqdsk:betan` for post-2000 shots.
- Remove existing `betan` fetching & computation in `cmod/efit.py`.
- Update CMOD output shape in `examples/efit.py`.