### PR TITLE
Updated get_surface_voltage computation

### DIFF
--- a/disruption_py/machine/cmod/physics.py
+++ b/disruption_py/machine/cmod/physics.py
@@ -1810,7 +1810,7 @@ class CmodPhysicsMethods:
     @physics_method(columns=["v_surf"], tokamak=Tokamak.CMOD)
     def get_surface_voltage(params: PhysicsMethodParams):
         """
-        Calculate the plasma surface voltage defined as v_surf=-deriv(SSIBRY)*2pi.
+        Calculate the plasma surface voltage defined as v_surf=-deriv(SIBDRY)*2pi.
 
         Note that there is a VSURFA node in the EFIT tree, however the stored data
         are all zeros for every shot.
@@ -1825,15 +1825,15 @@ class CmodPhysicsMethods:
         dict
             A dictionary containing the v_surf data.
 
-        Last major update by William Wei on 11/7/24
+        Last major update by William Wei on 12/3/24
         """
         # Get signals from EFIT tree
-        ssibry, efit_time = params.mds_conn.get_data_with_dims(
-            r"\efit_geqdsk:ssibry", tree_name="_efit_tree", astype="float64"
+        sibdry, efit_time = params.mds_conn.get_data_with_dims(
+            r"\efit_aeqdsk:sibdry", tree_name="_efit_tree", astype="float64"
         )  # [V*s/rad], [s]
 
         # Compute v_surf and interpolate to params.times
-        v_surf = -2 * np.pi * np.gradient(ssibry, efit_time)
+        v_surf = -2 * np.pi * np.gradient(sibdry, efit_time)
         v_surf = interp1(efit_time, v_surf, params.times)
 
         return {"v_surf": v_surf}


### PR DESCRIPTION
Changed `v_surf` computation from:
```
v_surf = -2pi*deriv(\efit_geqdsk:ssibry)
```
to:
```
v_surf = -2pi*deriv(\efit_aeqdsk:sibdry)
```
per suggestion from Stephen Wolfe.
Now `v_surf` will always have the same sign as `ip` regardless of the sign of `ip`

<img width="519" alt="image" src="https://github.com/user-attachments/assets/12f79493-2d76-4f43-a7f9-2b21f1f571cc">

(A positive ip case)

<img width="521" alt="image" src="https://github.com/user-attachments/assets/278909de-450c-47d2-8c5a-49058551016a">

(A negative ip case)