### PR TITLE
Fix commit hash test

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -12,10 +12,10 @@ def change_directory(test, tmpdir="/tmp"):
     Change the current working directory before a test and revert back to the
     original directory after the test completes.
     """
-    original_dir = os.getcwd()
-    os.chdir(tmpdir)
 
     def wrapper():
+        original_dir = os.getcwd()
+        os.chdir(tmpdir)
         test()
         os.chdir(original_dir)
 


### PR DESCRIPTION
## Problem

Currently, on dev, running pytest fails:
```
tests/test_retrieval_settings.py::test_cache_setting_prev_output[.csv] - AssertionError: Attributes of DataFrame.iloc[:, 62] (column name="commit_hash") are different
```

But running just that one test file succeeds:
```
pytest tests/test_retrieval_settings.py
```

## Proposed Solution
Modify the `change_directory` decorator to always change back to the current directory after changing to the `/tmp` directory.