### PR TITLE
Fix nan-multiplication error in get_peaking_factors for C-MOD

### DIFF
--- a/disruption_py/machine/cmod/physics.py
+++ b/disruption_py/machine/cmod/physics.py
@@ -1173,13 +1173,13 @@ class CmodPhysicsMethods:
         # Fetch data
         # Get EFIT geometry data
         z0 = params.mds_conn.get_data(
-            r"\efit_aeqdsk:zmagx/100", tree_name="_efit_tree", astype=np.float64
+            r"\efit_aeqdsk:zmagx/100", tree_name="_efit_tree", astype="float64"
         )  # [m]
         kappa = params.mds_conn.get_data(
-            r"\efit_aeqdsk:kappa", tree_name="_efit_tree", astype=np.float64
+            r"\efit_aeqdsk:kappa", tree_name="_efit_tree", astype="float64"
         )  # [dimensionless]
         aminor, efit_time = params.mds_conn.get_data_with_dims(
-            r"\efit_aeqdsk:aout/100", tree_name="_efit_tree", astype=np.float64
+            r"\efit_aeqdsk:aout/100", tree_name="_efit_tree", astype="float64"
         )  # [m], [s]
         bminor = aminor * kappa
 

--- a/disruption_py/machine/cmod/physics.py
+++ b/disruption_py/machine/cmod/physics.py
@@ -1181,7 +1181,9 @@ class CmodPhysicsMethods:
         aminor, efit_time = params.mds_conn.get_data_with_dims(
             r"\efit_aeqdsk:aout/100", tree_name="_efit_tree"
         )  # [m], [s]
-        bminor = aminor * kappa
+        # Avoid edge case error caused by NaN * 0
+        with np.errstate(invalid="ignore"):
+            bminor = aminor * kappa
 
         # Get Te data and TS time basis
         node_ext = ".yag_new.results.profiles"

--- a/disruption_py/machine/cmod/physics.py
+++ b/disruption_py/machine/cmod/physics.py
@@ -1173,17 +1173,15 @@ class CmodPhysicsMethods:
         # Fetch data
         # Get EFIT geometry data
         z0 = params.mds_conn.get_data(
-            r"\efit_aeqdsk:zmagx/100", tree_name="_efit_tree"
+            r"\efit_aeqdsk:zmagx/100", tree_name="_efit_tree", astype=np.float64
         )  # [m]
         kappa = params.mds_conn.get_data(
-            r"\efit_aeqdsk:kappa", tree_name="_efit_tree"
+            r"\efit_aeqdsk:kappa", tree_name="_efit_tree", astype=np.float64
         )  # [dimensionless]
         aminor, efit_time = params.mds_conn.get_data_with_dims(
-            r"\efit_aeqdsk:aout/100", tree_name="_efit_tree"
+            r"\efit_aeqdsk:aout/100", tree_name="_efit_tree", astype=np.float64
         )  # [m], [s]
-        # Avoid edge case error caused by NaN * 0
-        with np.errstate(invalid="ignore"):
-            bminor = aminor * kappa
+        bminor = aminor * kappa
 
         # Get Te data and TS time basis
         node_ext = ".yag_new.results.profiles"

--- a/disruption_py/machine/cmod/physics.py
+++ b/disruption_py/machine/cmod/physics.py
@@ -1186,24 +1186,26 @@ class CmodPhysicsMethods:
         # Get Te data and TS time basis
         node_ext = ".yag_new.results.profiles"
         ts_te_core, ts_time = params.mds_conn.get_data_with_dims(
-            f"{node_ext}:te_rz", tree_name="electrons"
+            f"{node_ext}:te_rz", tree_name="electrons", astype="float64"
         )  # [keV], [s]
         ts_te_core = ts_te_core * 1000  # [keV] -> [eV]
-        ts_te_edge = params.mds_conn.get_data(r"\ts_te")  # [eV]
+        ts_te_edge = params.mds_conn.get_data(r"\ts_te", astype="float64")  # [eV]
         ts_te = np.concatenate((ts_te_core, ts_te_edge)) * 11600  # [eV] -> [K]
 
         # Get ne data
         ts_ne_core = params.mds_conn.get_data(
-            f"{node_ext}:ne_rz", tree_name="electrons"
+            f"{node_ext}:ne_rz", tree_name="electrons", astype="float64"
         )  # [m^-3]
-        ts_ne_edge = params.mds_conn.get_data(r"\ts_ne")  # [m^-3]
+        ts_ne_edge = params.mds_conn.get_data(r"\ts_ne", astype="float64")  # [m^-3]
         ts_ne = np.concatenate((ts_ne_core, ts_ne_edge))
 
         # Get TS chord positions
         ts_z_core = params.mds_conn.get_data(
-            f"{node_ext}:z_sorted", tree_name="electrons"
+            f"{node_ext}:z_sorted", tree_name="electrons", astype="float64"
         )  # [m]
-        ts_z_edge = params.mds_conn.get_data(r"\fiber_z", tree_name="electrons")  # [m]
+        ts_z_edge = params.mds_conn.get_data(
+            r"\fiber_z", tree_name="electrons", astype="float64"
+        )  # [m]
         ts_z = np.concatenate((ts_z_core, ts_z_edge))
         # Make sure that there are equal numbers of edge position and edge temperature points
         if len(ts_z_edge) != ts_te_edge.shape[0]:

--- a/disruption_py/machine/cmod/physics.py
+++ b/disruption_py/machine/cmod/physics.py
@@ -1027,10 +1027,10 @@ class CmodPhysicsMethods:
         node_path = ".yag_new.results.profiles"
 
         ts_data, ts_time = params.mds_conn.get_data_with_dims(
-            node_path + ":te_rz", tree_name="electrons"
+            node_path + ":te_rz", tree_name="electrons", astype="float64"
         )  # [keV], [s]
         ts_z = params.mds_conn.get_data(
-            node_path + ":z_sorted", tree_name="electrons"
+            node_path + ":z_sorted", tree_name="electrons", astype="float64"
         )  # [m]
 
         output = CmodPhysicsMethods._get_ts_parameters(


### PR DESCRIPTION
Added a `np.errstate` context manager to avoid a `RuntimeWarning: invalid value encountered in multiply` error in `get_peaking_factors` computation.

Previously failing shot: 1150728005