### PR TITLE
Update console log levels for tests

### DIFF
--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -44,5 +44,6 @@ def test_tokamak_parameter(shotlist, tok):
         retrieval_settings=retrieval_settings,
         output_setting="list",
         num_processes=1,
+        log_settings="WARNING",
     )
     assert col_name in shot_data[0]

--- a/tests/test_retrieval_settings.py
+++ b/tests/test_retrieval_settings.py
@@ -136,6 +136,7 @@ def test_only_requested_columns(tokamak, shotlist):
         shotlist_setting=shotlist,
         retrieval_settings=retrieval_settings,
         num_processes=2,
+        log_settings="WARNING",
     )
     for res in results:
         assert {"ip", "q95", "shot", "time", "commit_hash"} == set(res.columns)
@@ -159,6 +160,7 @@ def test_domain_setting(tokamak, shotlist, domain_setting, full_time_domain_data
         retrieval_settings=retrieval_settings,
         output_setting="dict",
         num_processes=2,
+        log_settings="WARNING",
     )
     results = [results[shot] for shot in shotlist]
 

--- a/tests/utils/eval_against_sql.py
+++ b/tests/utils/eval_against_sql.py
@@ -52,7 +52,7 @@ def get_fresh_data(
             log_file_path=log_file_path,
             log_file_write_mode="w",
             file_log_level="DEBUG",
-            console_log_level="DEBUG",
+            console_log_level="WARNING",
         ),
     )
     return shot_data


### PR DESCRIPTION
remove debug and success logs from pytest runs -- they should still end up in the default log file anyway.