### PR TITLE
Tweak logging levels and colors

### DIFF
--- a/disruption_py/core/physics_method/runner.py
+++ b/disruption_py/core/physics_method/runner.py
@@ -183,9 +183,7 @@ def filter_methods_to_run(
             methods_to_run.append(bound_method_metadata)
         else:
             physics_method_params.logger.debug(
-                "Skipping {method_name} in {bound_method}",
-                method_name=bound_method_metadata.name,
-                bound_method=bound_method_metadata.bound_method.__qualname__,
+                "Skipping method: {name}", name=bound_method_metadata.name
             )
     return methods_to_run
 
@@ -241,7 +239,8 @@ def populate_method(
         physics_method_params.logger.opt(exception=True).debug(e)
         result = {col: [np.nan] for col in bound_method_metadata.columns}
 
-    physics_method_params.logger.info(
+    physics_method_params.logger.log(
+        "VERBOSE",
         "{t:.3f}s : {name}",
         name=name,
         t=time.time() - start_time,
@@ -303,8 +302,9 @@ def populate_shot(
             if cache_success:
                 cached_method_metadata.append(method_metadata)
                 if method_metadata in run_bound_method_metadata:
-                    physics_method_params.logger.info(
-                        "Skipping {name} already populated",
+                    physics_method_params.logger.log(
+                        "VERBOSE",
+                        "Cached method: {name}",
                         name=method_metadata.name,
                     )
 

--- a/disruption_py/core/physics_method/runner.py
+++ b/disruption_py/core/physics_method/runner.py
@@ -239,8 +239,7 @@ def populate_method(
         physics_method_params.logger.opt(exception=True).debug(e)
         result = {col: [np.nan] for col in bound_method_metadata.columns}
 
-    physics_method_params.logger.log(
-        "VERBOSE",
+    physics_method_params.logger.verbose(
         "{t:.3f}s : {name}",
         name=name,
         t=time.time() - start_time,
@@ -302,8 +301,7 @@ def populate_shot(
             if cache_success:
                 cached_method_metadata.append(method_metadata)
                 if method_metadata in run_bound_method_metadata:
-                    physics_method_params.logger.log(
-                        "VERBOSE",
+                    physics_method_params.logger.verbose(
                         "Cached method: {name}",
                         name=method_metadata.name,
                     )

--- a/disruption_py/inout/sql.py
+++ b/disruption_py/inout/sql.py
@@ -375,7 +375,7 @@ class ShotDatabase:
             self.engine,
         )
         if len(data_df) == 0:
-            logger.info(shot_log_msg(shot_id, "shot does not exist in database"))
+            logger.warning(shot_log_msg(shot_id, "shot does not exist in database"))
             return False
         with self.conn.cursor() as curs:
             curs.execute(

--- a/disruption_py/machine/d3d/physics.py
+++ b/disruption_py/machine/d3d/physics.py
@@ -136,7 +136,7 @@ class D3DPhysicsMethods:
                     fill_value=0.0,
                 )
             else:
-                params.logger.info("No NBI power data found in this shot.")
+                params.logger.log("VERBOSE", "No NBI power data found in this shot.")
                 p_nbi = np.zeros(len(params.times))
         except mdsExceptions.MdsException as e:
             p_nbi = np.zeros(len(params.times))
@@ -164,7 +164,8 @@ class D3DPhysicsMethods:
                     fill_value=0.0,
                 )
             else:
-                params.logger.info(
+                params.logger.log(
+                    "VERBOSE",
                     "No ECH power data found in this shot. Setting to zeros",
                 )
                 p_ech = np.zeros(len(params.times))
@@ -527,11 +528,10 @@ class D3DPhysicsMethods:
                 )
             )
             if len(polarity) > 1:
-                params.logger.info(
-                    (
-                        "Polarity of Ip target is not constant. "
-                        "Using value at first timestep."
-                    ),
+                params.logger.log(
+                    "VERBOSE",
+                    "Polarity of Ip target is not constant. "
+                    "Using value at first timestep.",
                 )
                 params.logger.debug("Polarity array {polarity}", polarity=polarity)
                 polarity = polarity[0]
@@ -650,7 +650,8 @@ class D3DPhysicsMethods:
                 )
             )
             if len(polarity) > 1:
-                params.logger.info(
+                params.logger.log(
+                    "VERBOSE",
                     "Polarity of Ip target is not constant."
                     " Setting to first value in array.",
                 )
@@ -1159,7 +1160,7 @@ class D3DPhysicsMethods:
             )
         else:
             zeff = np.zeros(len(params.times))
-            params.logger.info("No zeff data found in this shot.")
+            params.logger.log("VERBOSE", "No zeff data found in this shot.")
         return {"z_eff": zeff}
 
     @staticmethod

--- a/disruption_py/machine/d3d/physics.py
+++ b/disruption_py/machine/d3d/physics.py
@@ -136,7 +136,7 @@ class D3DPhysicsMethods:
                     fill_value=0.0,
                 )
             else:
-                params.logger.log("VERBOSE", "No NBI power data found in this shot.")
+                params.logger.verbose("No NBI power data found in this shot.")
                 p_nbi = np.zeros(len(params.times))
         except mdsExceptions.MdsException as e:
             p_nbi = np.zeros(len(params.times))
@@ -164,8 +164,7 @@ class D3DPhysicsMethods:
                     fill_value=0.0,
                 )
             else:
-                params.logger.log(
-                    "VERBOSE",
+                params.logger.verbose(
                     "No ECH power data found in this shot. Setting to zeros",
                 )
                 p_ech = np.zeros(len(params.times))
@@ -528,8 +527,7 @@ class D3DPhysicsMethods:
                 )
             )
             if len(polarity) > 1:
-                params.logger.log(
-                    "VERBOSE",
+                params.logger.verbose(
                     "Polarity of Ip target is not constant. "
                     "Using value at first timestep.",
                 )
@@ -650,8 +648,7 @@ class D3DPhysicsMethods:
                 )
             )
             if len(polarity) > 1:
-                params.logger.log(
-                    "VERBOSE",
+                params.logger.verbose(
                     "Polarity of Ip target is not constant."
                     " Setting to first value in array.",
                 )
@@ -1160,7 +1157,7 @@ class D3DPhysicsMethods:
             )
         else:
             zeff = np.zeros(len(params.times))
-            params.logger.log("VERBOSE", "No zeff data found in this shot.")
+            params.logger.verbose("No zeff data found in this shot.")
         return {"z_eff": zeff}
 
     @staticmethod

--- a/disruption_py/settings/domain_setting.py
+++ b/disruption_py/settings/domain_setting.py
@@ -257,7 +257,8 @@ class FlattopDomainSetting(DomainSetting):
                 )
             )
             if len(polarity) > 1:
-                params.logger.info(
+                params.logger.log(
+                    "VERBOSE",
                     "Polarity of Ip target is not constant. "
                     "Using value at first timestep.",
                 )

--- a/disruption_py/settings/domain_setting.py
+++ b/disruption_py/settings/domain_setting.py
@@ -257,8 +257,7 @@ class FlattopDomainSetting(DomainSetting):
                 )
             )
             if len(polarity) > 1:
-                params.logger.log(
-                    "VERBOSE",
+                params.logger.verbose(
                     "Polarity of Ip target is not constant. "
                     "Using value at first timestep.",
                 )

--- a/disruption_py/settings/domain_setting.py
+++ b/disruption_py/settings/domain_setting.py
@@ -258,8 +258,7 @@ class FlattopDomainSetting(DomainSetting):
             )
             if len(polarity) > 1:
                 params.logger.verbose(
-                    "Polarity of Ip target is not constant. "
-                    "Using value at first timestep.",
+                    "Polarity of Ip target is not constant. Using value at first timestep."
                 )
                 params.logger.debug("Polarity array {polarity}", polarity=polarity)
                 polarity = polarity[0]

--- a/disruption_py/settings/log_settings.py
+++ b/disruption_py/settings/log_settings.py
@@ -36,8 +36,9 @@ class LogSettings:
         By default, a log file will be created in a temporary folder.
     file_log_level : str
         Logging level for the log file (default is "DEBUG").
-        Possible values are: "TRACE", "DEBUG", "INFO", "SUCCESS", "WARNING", "ERROR",
-        "CRITICAL". See https://loguru.readthedocs.io/en/stable/api/logger.html#levels
+        Possible values are:
+        "TRACE", "DEBUG", "VERBOSE" (custom), "INFO", "SUCCESS", "WARNING", "ERROR", "CRITICAL".
+        See: https://loguru.readthedocs.io/en/stable/api/logger.html#levels
     log_file_write_mode : str, optional
         The write mode for the log file. Default is "w".
     log_to_console : bool
@@ -45,9 +46,9 @@ class LogSettings:
     console_log_level : str or int, optional
         The log level for the console. Default is None, so log level will be determined
         dynamically based on the number of shots.
-        Possible values are: "TRACE", "DEBUG", "VERBOSE" (custom level), "INFO", "SUCCESS",
-        "WARNING", "ERROR", "CRITICAL".
-        See https://loguru.readthedocs.io/en/stable/api/logger.html#levels
+        Possible values are:
+        "TRACE", "DEBUG", "VERBOSE" (custom), "INFO", "SUCCESS", "WARNING", "ERROR", "CRITICAL".
+        See: https://loguru.readthedocs.io/en/stable/api/logger.html#levels
     use_custom_logging : bool
         Whether to use custom logging. If set to true, no logging setup will be done.
         Default is False.

--- a/disruption_py/settings/log_settings.py
+++ b/disruption_py/settings/log_settings.py
@@ -45,8 +45,9 @@ class LogSettings:
     console_log_level : str or int, optional
         The log level for the console. Default is None, so log level will be determined
         dynamically based on the number of shots.
-        Possible values are: "TRACE", "DEBUG", "INFO", "SUCCESS", "WARNING", "ERROR",
-        "CRITICAL". See https://loguru.readthedocs.io/en/stable/api/logger.html#levels
+        Possible values are: "TRACE", "DEBUG", "VERBOSE" (custom level), "INFO", "SUCCESS",
+        "WARNING", "ERROR", "CRITICAL".
+        See https://loguru.readthedocs.io/en/stable/api/logger.html#levels
     use_custom_logging : bool
         Whether to use custom logging. If set to true, no logging setup will be done.
         Default is False.
@@ -56,6 +57,9 @@ class LogSettings:
     success_threshold : int
         If number of shots is greater than this threshold and less than the warning_threshold,
         the console log level will be "SUCCESS". Default is 500.
+    info_threshold : int
+        If number of shots is greater than this threshold and less than the success_threshold,
+        the console log level will be "INFO". Default is 50.
     _logging_has_been_setup : bool
         Internal flag to prevent multiple setups (default is False).
     """
@@ -71,6 +75,7 @@ class LogSettings:
 
     warning_threshold: int = 1000
     success_threshold: int = 500
+    info_threshold: int = 50
 
     _logging_has_been_setup: bool = False
 
@@ -93,11 +98,13 @@ class LogSettings:
 
         if self.console_log_level is None:
             # Determine console log level dynamically based on the number of shots
-            console_level = "INFO"
+            console_level = "VERBOSE"
             if num_shots and num_shots > self.warning_threshold:
                 console_level = "WARNING"
             elif num_shots and num_shots > self.success_threshold:
                 console_level = "SUCCESS"
+            elif num_shots and num_shots > self.info_threshold:
+                console_level = "INFO"
         elif isinstance(self.console_log_level, str):
             console_level = self.console_log_level.upper()
         else:

--- a/disruption_py/settings/log_settings.py
+++ b/disruption_py/settings/log_settings.py
@@ -85,8 +85,10 @@ class LogSettings:
         # Remove default logger
         logger.remove()
 
-        # Set colors without any bolding for each level (levels are bold by default)
-        logger.level("DEBUG", color="<dim>")
+        # Set custom style and add a VERBOSE level
+        logger.level("TRACE", color="<cyan><dim>")
+        logger.level("DEBUG", color="<blue>")
+        logger.level("VERBOSE", color="<dim>", no=15)
         logger.level("INFO", color="")
         logger.level("SUCCESS", color="<green>")
         logger.level("WARNING", color="<yellow>")

--- a/disruption_py/settings/log_settings.py
+++ b/disruption_py/settings/log_settings.py
@@ -148,7 +148,12 @@ class LogSettings:
         # once, so there is no need to add it to the reset_handlers method.
         logger.level("TRACE", color="<cyan><dim>")
         logger.level("DEBUG", color="<blue>")
-        logger.level("VERBOSE", color="<dim>", no=15)
+        # Ensure the level does not already exist because the level no can only
+        # be added once. This might happen if the logger is re-initialized.
+        try:
+            logger.level("VERBOSE", color="<dim>")
+        except ValueError:
+            logger.level("VERBOSE", color="<dim>", no=15)
         logger.level("INFO", color="")
         logger.level("SUCCESS", color="<green>")
         logger.level("WARNING", color="<yellow>")

--- a/disruption_py/settings/log_settings.py
+++ b/disruption_py/settings/log_settings.py
@@ -136,17 +136,7 @@ class LogSettings:
 
     def setup_logging(self):
         """
-        Set up logging based on the provided settings.
-
-        Parameters
-        ----------
-        logger_name : str, optional
-            Name of the logger (default is "disruption_py").
-
-        Returns
-        -------
-        logging.Logger
-            Configured logger instance.
+        Set up logging with custom styles and levels.
         """
         if self.use_custom_logging or self._logging_has_been_setup:
             return

--- a/disruption_py/settings/log_settings.py
+++ b/disruption_py/settings/log_settings.py
@@ -9,6 +9,7 @@ import importlib.metadata
 import os
 import sys
 from dataclasses import dataclass
+from functools import partialmethod
 from typing import Union
 
 from loguru import logger
@@ -85,15 +86,6 @@ class LogSettings:
         # Remove default logger
         logger.remove()
 
-        # Set custom style and add a VERBOSE level
-        logger.level("TRACE", color="<cyan><dim>")
-        logger.level("DEBUG", color="<blue>")
-        logger.level("VERBOSE", color="<dim>", no=15)
-        logger.level("INFO", color="")
-        logger.level("SUCCESS", color="<green>")
-        logger.level("WARNING", color="<yellow>")
-        logger.level("ERROR", color="<red>")
-
         # formats
         message_format = "<level>[{level:^7s}] {message}</level>"
         console_format = "{time:HH:mm:ss.SSS} " + message_format
@@ -151,6 +143,19 @@ class LogSettings:
         """
         if self.use_custom_logging or self._logging_has_been_setup:
             return
+
+        # Set custom style and add a VERBOSE level. This only needs to be done
+        # once, so there is no need to add it to the reset_handlers method.
+        logger.level("TRACE", color="<cyan><dim>")
+        logger.level("DEBUG", color="<blue>")
+        logger.level("VERBOSE", color="<dim>", no=15)
+        logger.level("INFO", color="")
+        logger.level("SUCCESS", color="<green>")
+        logger.level("WARNING", color="<yellow>")
+        logger.level("ERROR", color="<red>")
+        # Bind the verbose level to the class so it can be used in any file even
+        # after changing the logger instance
+        logger.__class__.verbose = partialmethod(logger.__class__.log, "VERBOSE")
 
         self.reset_handlers(num_shots=None)
 

--- a/disruption_py/settings/log_settings.py
+++ b/disruption_py/settings/log_settings.py
@@ -157,7 +157,7 @@ class LogSettings:
         # header
         package = "disruption_py"
         commit = get_commit_hash()
-        logger.success(
+        logger.info(
             "Starting: {p} ~ v{v} # {c} / {u}@{h}",
             p=package,
             v=importlib.metadata.version(package),

--- a/examples/all_defaults_example.py
+++ b/examples/all_defaults_example.py
@@ -37,7 +37,7 @@ shot_data = get_shots_data(
         file_log_level="DEBUG",
         log_file_write_mode="w",
         log_to_console=True,
-        console_log_level=None,  # defaults to INFO but varies based on number of shots
+        console_log_level=None,  # defaults to VERBOSE but varies based on number of shots
         use_custom_logging=False,
     ),
 )


### PR DESCRIPTION
- add a new `VERBOSE` level above `DEBUG` but below `INFO` (eg: for output of physics methods),
- tweak some colors, 
- downgrade some logging lines.

to do:
- [x] is there a way to call `logger.verbose("stuff")` as opposed to `logger.log("VERBOSE", "stuff")`?
- [x] it looks like we are setting up the logger multiple times, and that errors out.
