### PR TITLE
Cast data to float64 by default

### DIFF
--- a/disruption_py/inout/mds.py
+++ b/disruption_py/inout/mds.py
@@ -165,7 +165,7 @@ class MDSConnection:
         self,
         path: str,
         tree_name: str = None,
-        astype: str = None,
+        astype: str = "float64",
         arguments: Any = None,
     ) -> np.ndarray:
         """
@@ -177,7 +177,7 @@ class MDSConnection:
             MDSplus path to record.
         tree_name : str, optional
             The name of the tree that must be open for retrieval.
-        astype : str, optional
+        astype : str, optional, default = "float64"
             The data type for explicit casting.
         arguments : Any, optional
             Arguments for MDSplus TDI Expression. Default None.
@@ -205,7 +205,7 @@ class MDSConnection:
         path: str,
         tree_name: str = None,
         dim_nums: List = None,
-        astype: str = None,
+        astype: str = "float64",
         cast_all: bool = False,
     ) -> Tuple:
         """
@@ -219,7 +219,7 @@ class MDSConnection:
             The name of the tree that must be open for retrieval.
         dim_nums : List, optional
             A list of dimensions that should have their size retrieved. Default [0].
-        astype : str, optional
+        astype : str, optional, default = "float64"
             The data type for explicit casting.
         cast_all : bool, optional. Default False.
             Whether to cast both data and dims, or only data.

--- a/disruption_py/machine/cmod/efit.py
+++ b/disruption_py/machine/cmod/efit.py
@@ -70,7 +70,7 @@ class CmodEfitMethods:
             A dictionary containing the retrieved EFIT parameters.
         """
         efit_time = params.mds_conn.get_data(
-            r"\efit_aeqdsk:time", tree_name="_efit_tree", astype="float64"
+            r"\efit_aeqdsk:time", tree_name="_efit_tree"
         )  # [s]
         efit_data = {}
 
@@ -80,7 +80,6 @@ class CmodEfitMethods:
                 efit_data[param] = params.mds_conn.get_data(
                     path=path,
                     tree_name="_efit_tree",
-                    astype="float64",
                 )
             except mdsExceptions.MdsException as e:
                 params.logger.warning(

--- a/disruption_py/machine/cmod/physics.py
+++ b/disruption_py/machine/cmod/physics.py
@@ -208,7 +208,9 @@ class CmodPhysicsMethods:
             # Ip wire can be one of 16 but is normally no. 16
             for wire_index in range(16, 0, -1):
                 wire_node_name = params.mds_conn.get_data(
-                    node_path + f":P_{wire_index :02d}:name", tree_name="pcs"
+                    node_path + f":P_{wire_index :02d}:name",
+                    tree_name="pcs",
+                    astype=None,
                 )
                 if wire_node_name == "IP":
                     try:
@@ -357,7 +359,9 @@ class CmodPhysicsMethods:
         for node_path, start in active_wire_segments:
             for wire_index in range(1, 17):
                 wire_node_name = params.mds_conn.get_data(
-                    node_path + f":P_{wire_index:02d}:name", tree_name="pcs"
+                    node_path + f":P_{wire_index:02d}:name",
+                    tree_name="pcs",
+                    astype=None,
                 )
                 if wire_node_name == "ZCUR":
                     try:
@@ -628,7 +632,7 @@ class CmodPhysicsMethods:
         for i in range(3):
             try:
                 sig, sig_time = params.mds_conn.get_data_with_dims(
-                    nodes[i], tree_name=trees[i]
+                    nodes[i], tree_name=trees[i], astype=None
                 )
                 values[2 * i] = sig
                 values[2 * i + 1] = sig_time
@@ -745,7 +749,7 @@ class CmodPhysicsMethods:
 
         path = r"\mag_bp_coils."
         bp_node_names = params.mds_conn.get_data(
-            path + "nodename", tree_name="magnetics"
+            path + "nodename", tree_name="magnetics", astype=None
         )
         phi = params.mds_conn.get_data(path + "phi", tree_name="magnetics")  # [degree]
         btor_pickup_coeffs = params.mds_conn.get_data(

--- a/disruption_py/machine/cmod/physics.py
+++ b/disruption_py/machine/cmod/physics.py
@@ -242,7 +242,7 @@ class CmodPhysicsMethods:
                         params.logger.opt(exception=True).debug(e)
                     break  # Break out of wire_index loop
         ip, magtime = params.mds_conn.get_data_with_dims(
-            r"\ip", tree_name="magnetics", astype="float64"
+            r"\ip", tree_name="magnetics"
         )  # [A], [s]
         output = CmodPhysicsMethods._get_ip_parameters(
             params.times, ip, magtime, ip_prog, pcstime
@@ -508,13 +508,13 @@ class CmodPhysicsMethods:
             "p_oh" and "v_loop".
         """
         v_loop, v_loop_time = params.mds_conn.get_data_with_dims(
-            r"\top.mflux:v0", tree_name="analysis", astype="float64"
+            r"\top.mflux:v0", tree_name="analysis"
         )  # [V], [s]
         if len(v_loop_time) <= 1:
             raise CalculationError("No data for v_loop_time")
 
         li, efittime = params.mds_conn.get_data_with_dims(
-            r"\efit_aeqdsk:ali", tree_name="_efit_tree", astype="float64"
+            r"\efit_aeqdsk:ali", tree_name="_efit_tree"
         )  # [dimensionless], [s]
         ip_parameters = CmodPhysicsMethods.get_ip_parameters(params=params)
         r0 = params.mds_conn.get_data(
@@ -628,7 +628,7 @@ class CmodPhysicsMethods:
         for i in range(3):
             try:
                 sig, sig_time = params.mds_conn.get_data_with_dims(
-                    nodes[i], tree_name=trees[i], astype="float64"
+                    nodes[i], tree_name=trees[i]
                 )
                 values[2 * i] = sig
                 values[2 * i + 1] = sig_time
@@ -680,13 +680,13 @@ class CmodPhysicsMethods:
             A dictionary containing the calculated "kappa_area".
         """
         aminor = params.mds_conn.get_data(
-            r"\efit_aeqdsk:aout/100", tree_name="_efit_tree", astype="float64"
+            r"\efit_aeqdsk:aout/100", tree_name="_efit_tree"
         )  # [m]
         area = params.mds_conn.get_data(
-            r"\efit_aeqdsk:areao/1e4", tree_name="_efit_tree", astype="float64"
+            r"\efit_aeqdsk:areao/1e4", tree_name="_efit_tree"
         )  # [m^2]
         times = params.mds_conn.get_data(
-            r"\efit_aeqdsk:time", tree_name="_efit_tree", astype="float64"
+            r"\efit_aeqdsk:time", tree_name="_efit_tree"
         )  # [s]
 
         aminor[aminor <= 0] = 0.001  # make sure aminor is not 0 or less than 0
@@ -878,17 +878,17 @@ class CmodPhysicsMethods:
         """
         # Line-integrated density
         n_e, t_n = params.mds_conn.get_data_with_dims(
-            r".tci.results:nl_04", tree_name="electrons", astype="float64"
+            r".tci.results:nl_04", tree_name="electrons"
         )  # [m^-3], [s]
         # Divide by chord length of ~0.6m to get line averaged density.
         # For future refernce, chord length is stored in
         # .01*\analysis::efit_aeqdsk:rco2v[3,*]
         n_e = np.squeeze(n_e) / 0.6
         ip, t_ip = params.mds_conn.get_data_with_dims(
-            r"\ip", tree_name="magnetics", astype="float64"
+            r"\ip", tree_name="magnetics"
         )  # [A], [s]
         a_minor, t_a = params.mds_conn.get_data_with_dims(
-            r"\efit_aeqdsk:aout/100", tree_name="_efit_tree", astype="float64"
+            r"\efit_aeqdsk:aout/100", tree_name="_efit_tree"
         )  # [m], [s]
 
         output = CmodPhysicsMethods._get_densities(
@@ -1743,7 +1743,6 @@ class CmodPhysicsMethods:
         sxr, t_sxr = params.mds_conn.get_data_with_dims(
             r"\top.brightnesses.array_1:chord_16",
             tree_name="xtomo",
-            astype="float64",
         )  # [W/m^2], [s]
         sxr = interp1(t_sxr, sxr, params.times)
         return {"sxr": sxr}
@@ -1784,16 +1783,16 @@ class CmodPhysicsMethods:
         """
         # Get signals from EFIT tree
         beta_t, efittime = params.mds_conn.get_data_with_dims(
-            r"\efit_aeqdsk:betat", tree_name="_efit_tree", astype="float64"
+            r"\efit_aeqdsk:betat", tree_name="_efit_tree"
         )  # [%], [s]
         ip = params.mds_conn.get_data(
-            r"\efit_aeqdsk:cpasma/1e6", tree_name="_efit_tree", astype="float64"
+            r"\efit_aeqdsk:cpasma/1e6", tree_name="_efit_tree"
         )  # [MA]
         aminor = params.mds_conn.get_data(
-            r"\efit_aeqdsk:aout/100", tree_name="_efit_tree", astype="float64"
+            r"\efit_aeqdsk:aout/100", tree_name="_efit_tree"
         )  # [m]
         btor = params.mds_conn.get_data(
-            r"\efit_aeqdsk:btaxp", tree_name="_efit_tree", astype="float64"
+            r"\efit_aeqdsk:btaxp", tree_name="_efit_tree"
         )  # [T]
 
         # Calculate beta_n
@@ -1829,7 +1828,7 @@ class CmodPhysicsMethods:
         """
         # Get signals from EFIT tree
         sibdry, efit_time = params.mds_conn.get_data_with_dims(
-            r"\efit_aeqdsk:sibdry", tree_name="_efit_tree", astype="float64"
+            r"\efit_aeqdsk:sibdry", tree_name="_efit_tree"
         )  # [V*s/rad], [s]
 
         # Compute v_surf and interpolate to params.times

--- a/disruption_py/machine/cmod/thomson.py
+++ b/disruption_py/machine/cmod/thomson.py
@@ -194,7 +194,7 @@ class CmodThomsonDensityMeasure:
         if np.mean(ip) > 0:
             flag = 0
         efit_times = params.mds_conn.get_data(
-            r"\efit_aeqdsk:time", tree_name="_efit_tree", astype="float64"
+            r"\efit_aeqdsk:time", tree_name="_efit_tree"
         )
         t1 = np.amin(efit_times)
         t2 = np.amax(efit_times)

--- a/disruption_py/machine/d3d/physics.py
+++ b/disruption_py/machine/d3d/physics.py
@@ -122,7 +122,7 @@ class D3DPhysicsMethods:
         # Get neutral beam injected power
         try:
             p_nbi, t_nbi = params.mds_conn.get_data_with_dims(
-                r"\d3d::top.nb:pinj", tree_name="d3d", astype="float64"
+                r"\d3d::top.nb:pinj", tree_name="d3d"
             )
             t_nbi /= 1e3  # [ms] -> [s]
             p_nbi *= 1e3  # [KW] -> [W]


### PR DESCRIPTION
in order to avoid these pesky nan-related issues:
- cast all _data_ calls to float64 by default,
- remove explicit assignments from physics methods,
- introduce overrides for strings/names.

[rationale by Amos](https://github.com/MIT-PSFC/disruption-py/issues/359#issuecomment-2537071992):
> There are two types of nans: signaling nans and silent nans. When we do an operation with signaling nans (e.g. nan * 1) it will give us a warning. If we do an operation with silent nans, the operation will give nan.  It seems like MDSPlus uses signaling nans which is why there is this warning. To get rid of the warning, we could turn them into silent nans (the numpy default) by converting the arrays to np.float64 using the `astype` parameter in the mds call.

supersedes:
- #359