### PR TITLE
Limit Dependabot to GH actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,18 +3,9 @@
 version: 2
 updates:
 
-  - package-ecosystem: "pip"
-    directory: "/"
-    target-branch: "dev"
-    versioning-strategy: increase-if-necessary
-    schedule:
-      interval: "monthly"
-    reviewers:
-      - gtrevisan
-    open-pull-requests-limit: 10
-
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "dev"
     schedule:
       interval: "monthly"
     reviewers:


### PR DESCRIPTION
Dependabot was not super useful for our python dependencies since it was missing all workflow variables and secrets, and because its lowest frequency, which was monthly, was still higher than desired.
We will continue with manual dependency updates and tests at will.

EDIT: let's keep it for GH actions updates only!