### PR TITLE
Improve get_power and get_ohmic_parameters for C-MOD

### DIFF
--- a/disruption_py/machine/cmod/physics.py
+++ b/disruption_py/machine/cmod/physics.py
@@ -619,6 +619,7 @@ class CmodPhysicsMethods:
         wmhd = interp1(efit_time, wmhd, times)
         with np.errstate(divide="ignore", invalid="ignore"):
             tau_rad = wmhd / p_rad
+        tau_rad[tau_rad == np.inf] = np.nan
         output = {
             "p_rad": p_rad,
             "dprad_dt": dprad,

--- a/disruption_py/machine/cmod/physics.py
+++ b/disruption_py/machine/cmod/physics.py
@@ -514,7 +514,7 @@ class CmodPhysicsMethods:
                 r"\top.mflux:v0", tree_name="analysis"
             )  # [V], [s]
         except mdsExceptions.TreeException:
-            params.logger.warning(
+            params.logger.verbose(
                 r"v_loop: Failed to get \top.mflux:v0 data. Use \efit_aeqdsk:vloopt instead."
             )
             v_loop, v_loop_time = params.mds_conn.get_data_with_dims(

--- a/disruption_py/machine/cmod/physics.py
+++ b/disruption_py/machine/cmod/physics.py
@@ -652,7 +652,7 @@ class CmodPhysicsMethods:
         tokamak=Tokamak.CMOD,
     )
     def get_power(params: PhysicsMethodParams):
-        """
+        r"""
         NOTE: the timebase for the LH power signal does not extend over the full
             time span of the discharge. Therefore, when interpolating the LH power
             signal onto the "timebase" array, the LH signal has to be extrapolated

--- a/disruption_py/machine/cmod/physics.py
+++ b/disruption_py/machine/cmod/physics.py
@@ -509,9 +509,14 @@ class CmodPhysicsMethods:
             A dictionary containing the calculated ohmic parameters, including
             "p_oh" and "v_loop".
         """
-        v_loop, v_loop_time = params.mds_conn.get_data_with_dims(
-            r"\top.mflux:v0", tree_name="analysis"
-        )  # [V], [s]
+        try:
+            v_loop, v_loop_time = params.mds_conn.get_data_with_dims(
+                r"\top.mflux:v0", tree_name="analysis"
+            )  # [V], [s]
+        except mdsExceptions.TreeException:
+            v_loop, v_loop_time = params.mds_conn.get_data_with_dims(
+                r"\efit_aeqdsk:vloopt", tree_name="_efit_tree"
+            )  # [V], [s]
         if len(v_loop_time) <= 1:
             raise CalculationError("No data for v_loop_time")
 
@@ -665,7 +670,9 @@ class CmodPhysicsMethods:
                 kwa[p], kwa[t] = None, None
         # Ohmic power
         try:
-            kwa["p_ohm"] = CmodPhysicsMethods.get_ohmic_parameters(params=params)["p_oh"]
+            kwa["p_ohm"] = CmodPhysicsMethods.get_ohmic_parameters(params=params)[
+                "p_oh"
+            ]
         except mdsExceptions.TreeException:
             kwa["p_ohm"] = np.full(len(params.times), np.nan)
         # Plasma magnetic energy, and respective time base

--- a/disruption_py/machine/cmod/physics.py
+++ b/disruption_py/machine/cmod/physics.py
@@ -603,7 +603,7 @@ class CmodPhysicsMethods:
             dprad = interp1(t_rad, dprad, times)
 
         # Replace nans with zeros in p_ohm
-        p_ohm = np.nan_to_num(p_ohm)
+        p_ohm = np.nan_to_num(p_ohm, nan=0.0)
 
         # Calculate radiated fraction
         p_input = p_ohm + p_lh + p_icrf
@@ -666,7 +666,7 @@ class CmodPhysicsMethods:
         # Ohmic power
         try:
             kwa["p_ohm"] = CmodPhysicsMethods.get_ohmic_parameters(params=params)["p_oh"]
-        except mdsExceptions.TreeNODATA:
+        except mdsExceptions.TreeException:
             kwa["p_ohm"] = np.full(len(params.times), np.nan)
         # Plasma magnetic energy, and respective time base
         kwa["wmhd"], kwa["efit_time"] = params.mds_conn.get_data_with_dims(

--- a/disruption_py/machine/cmod/physics.py
+++ b/disruption_py/machine/cmod/physics.py
@@ -587,12 +587,12 @@ class CmodPhysicsMethods:
 
         """
         if p_lh is not None and isinstance(t_lh, np.ndarray) and len(t_lh) > 1:
-            p_lh = interp1(t_lh, p_lh * 1.0e3, times, fill_value=0) # [kW] -> [W]
+            p_lh = interp1(t_lh, p_lh * 1.0e3, times, fill_value=0)  # [kW] -> [W]
         else:
             p_lh = np.zeros(len(times))
 
         if p_icrf is not None and isinstance(t_icrf, np.ndarray) and len(t_icrf) > 1:
-            p_icrf = interp1(t_icrf, p_icrf * 1.0e6, times, fill_value=0)   # [MW] -> [W]
+            p_icrf = interp1(t_icrf, p_icrf * 1.0e6, times, fill_value=0)  # [MW] -> [W]
         else:
             p_icrf = np.zeros(len(times))
 
@@ -660,7 +660,7 @@ class CmodPhysicsMethods:
             extrapolation is not done, then the 'interp1' routine will assign NaN
             (Not-a-Number) values for times outside the LH timebase, and the NaN's
             will propagate into p_input and rad_fraction, which is not desirable.
-            
+
         LH, ICRF, & radiated power data sources:
         - lh: \lh::top.results.netpow [kW]
         - icrf: \rf::top.antenna.results.pwr_net_tot [MW]

--- a/disruption_py/machine/cmod/physics.py
+++ b/disruption_py/machine/cmod/physics.py
@@ -514,6 +514,9 @@ class CmodPhysicsMethods:
                 r"\top.mflux:v0", tree_name="analysis"
             )  # [V], [s]
         except mdsExceptions.TreeException:
+            params.logger.warning(
+                r"v_loop: Failed to get \top.mflux:v0 data. Use \efit_aeqdsk:vloopt instead."
+            )
             v_loop, v_loop_time = params.mds_conn.get_data_with_dims(
                 r"\efit_aeqdsk:vloopt", tree_name="_efit_tree"
             )  # [V], [s]
@@ -569,7 +572,7 @@ class CmodPhysicsMethods:
         wmhd : np.ndarray
             The total plasma energy.
         efit_time : np.ndarray
-            The EFIT time base
+            The EFIT time base.
 
         Returns
         -------
@@ -578,6 +581,10 @@ class CmodPhysicsMethods:
             "p_rad", "dprad_dt", "p_lh", "p_icrf", "p_input", "radiated_fraction", and "tau_rad".
 
         Last major update by William Wei on 1/6/2025
+        References
+        ----------
+        - https://github.com/MIT-PSFC/disruption-py/pull/367
+
         """
         if p_lh is not None and isinstance(t_lh, np.ndarray) and len(t_lh) > 1:
             p_lh = interp1(t_lh, p_lh * 1.0e3, times, fill_value=0)
@@ -671,9 +678,8 @@ class CmodPhysicsMethods:
                 kwa[p], kwa[t] = None, None
         # Ohmic power
         try:
-            kwa["p_ohm"] = CmodPhysicsMethods.get_ohmic_parameters(params=params)[
-                "p_oh"
-            ]
+            result = CmodPhysicsMethods.get_ohmic_parameters(params=params)
+            kwa["p_ohm"] = result["p_oh"]  # [W]
         except mdsExceptions.TreeException:
             kwa["p_ohm"] = np.full(len(params.times), np.nan)
         # Plasma magnetic energy, and respective time base

--- a/disruption_py/machine/cmod/physics.py
+++ b/disruption_py/machine/cmod/physics.py
@@ -608,7 +608,7 @@ class CmodPhysicsMethods:
             dprad = interp1(t_rad, dprad, times)
 
         # Replace nans with zeros in p_ohm
-        p_ohm = np.nan_to_num(p_ohm, nan=0.0)
+        np.nan_to_num(p_ohm, copy=False, nan=0.0)
 
         # Calculate radiated fraction
         p_input = p_ohm + p_lh + p_icrf

--- a/disruption_py/machine/cmod/physics.py
+++ b/disruption_py/machine/cmod/physics.py
@@ -624,9 +624,7 @@ class CmodPhysicsMethods:
 
         # Calculate radiation confinement time
         wmhd = interp1(efit_time, wmhd, times)
-        with np.errstate(divide="ignore", invalid="ignore"):
-            tau_rad = wmhd / p_rad
-        tau_rad[tau_rad == np.inf] = np.nan
+        tau_rad = wmhd / np.where(p_rad != 0, p_rad, np.nan)
         output = {
             "p_rad": p_rad,
             "dprad_dt": dprad,

--- a/disruption_py/machine/cmod/physics.py
+++ b/disruption_py/machine/cmod/physics.py
@@ -676,7 +676,7 @@ class CmodPhysicsMethods:
             t = f"t_{val}"
             try:
                 kwa[p], kwa[t] = params.mds_conn.get_data_with_dims(
-                    node, tree_name=tree, astype=None
+                    node, tree_name=tree
                 )
             except (mdsExceptions.TreeFOPENR, mdsExceptions.TreeNNF):
                 kwa[p], kwa[t] = None, None

--- a/disruption_py/machine/cmod/physics.py
+++ b/disruption_py/machine/cmod/physics.py
@@ -668,8 +668,8 @@ class CmodPhysicsMethods:
         """
         # LH power, ICRF power, radiated power, and respective time bases
         values = ["lh", "icrf", "rad"]
-        trees = ["LH", "RF", "spectroscopy"]
-        nodes = [r"\TOP.RESULTS:NETPOW", r"\rf_power_net", r"\twopi_diode"]
+        trees = ["lh", "rf", "spectroscopy"]
+        nodes = [r"\top.results:netpow", r"\rf_power_net", r"\twopi_diode"]
         kwa = {}
         for val, tree, node in zip(values, trees, nodes):
             p = f"p_{val}"

--- a/disruption_py/machine/cmod/physics.py
+++ b/disruption_py/machine/cmod/physics.py
@@ -602,8 +602,8 @@ class CmodPhysicsMethods:
             p_rad = interp1(t_rad, p_rad, times, fill_value=0)
             dprad = interp1(t_rad, dprad, times)
 
-        if all(np.isnan(p_ohm)):
-            p_ohm = np.zeros(len(times))
+        # Replace nans with zeros in p_ohm
+        p_ohm = np.nan_to_num(p_ohm)
 
         # Calculate radiated fraction
         p_input = p_ohm + p_lh + p_icrf

--- a/disruption_py/machine/cmod/physics.py
+++ b/disruption_py/machine/cmod/physics.py
@@ -587,12 +587,12 @@ class CmodPhysicsMethods:
 
         """
         if p_lh is not None and isinstance(t_lh, np.ndarray) and len(t_lh) > 1:
-            p_lh = interp1(t_lh, p_lh * 1.0e3, times, fill_value=0)
+            p_lh = interp1(t_lh, p_lh * 1.0e3, times, fill_value=0) # [kW] -> [W]
         else:
             p_lh = np.zeros(len(times))
 
         if p_icrf is not None and isinstance(t_icrf, np.ndarray) and len(t_icrf) > 1:
-            p_icrf = interp1(t_icrf, p_icrf * 1.0e6, times, fill_value=0)
+            p_icrf = interp1(t_icrf, p_icrf * 1.0e6, times, fill_value=0)   # [MW] -> [W]
         else:
             p_icrf = np.zeros(len(times))
 
@@ -602,10 +602,10 @@ class CmodPhysicsMethods:
             or not isinstance(t_rad, np.ndarray)
             or len(t_rad) <= 1
         ):
-            p_rad = np.array([np.nan] * len(times))  # TODO: Fix
+            p_rad = np.full(len(times), np.nan)
             dprad = p_rad.copy()
         else:
-            p_rad = p_rad * 1.0e3  # [W]
+            p_rad = p_rad * 1.0e3  # [kW] -> [W]
             p_rad = p_rad * 4.5  # Factor of 4.5 comes from cross-calibration with
             # 2pi_foil during flattop times of non-disruptive
             # shots, excluding times for
@@ -660,13 +660,17 @@ class CmodPhysicsMethods:
             extrapolation is not done, then the 'interp1' routine will assign NaN
             (Not-a-Number) values for times outside the LH timebase, and the NaN's
             will propagate into p_input and rad_fraction, which is not desirable.
+            
+        LH, ICRF, & radiated power data sources:
+        - lh: \lh::top.results.netpow [kW]
+        - icrf: \rf::top.antenna.results.pwr_net_tot [MW]
+        - rad: \spectroscopy::top.bolometer.twopi_diode [kW]
         """
         # LH power, ICRF power, radiated power, and respective time bases
         values = ["lh", "icrf", "rad"]
         trees = ["LH", "RF", "spectroscopy"]
         nodes = [r"\TOP.RESULTS:NETPOW", r"\rf_power_net", r"\twopi_diode"]
         kwa = {}
-        # TODO: Find these nodes and add units
         for val, tree, node in zip(values, trees, nodes):
             p = f"p_{val}"
             t = f"t_{val}"

--- a/disruption_py/machine/cmod/physics.py
+++ b/disruption_py/machine/cmod/physics.py
@@ -612,7 +612,8 @@ class CmodPhysicsMethods:
 
         # Calculate radiation confinement time
         wmhd = interp1(efit_time, wmhd, times)
-        tau_rad = wmhd / p_rad
+        with np.errstate(divide="ignore", invalid="ignore"):
+            tau_rad = wmhd / p_rad
         output = {
             "p_rad": p_rad,
             "dprad_dt": dprad,


### PR DESCRIPTION
# Original problems

1. `p_lh` and `p_rad` data stored in the MDSplus trees have shorter time bases than EFIT for a few shots (e.g. 1120208014 and 1050725002). This causes disruption-py to return nans for these signals (plus `p_input` and `radiated_fraction` which use these signals in their computation) in the missing time period, subsequently causing the ONW module to give bad predictions during these periods.
2. `get_ohmic_parameters` method fails for a few shots (e.g. 1050608005), which also causes `get_power` to fail.

![image](https://github.com/user-attachments/assets/68fdbd71-10f0-4a60-b4bf-2e765236d2d5)
![image](https://github.com/user-attachments/assets/c56d8fff-a1cc-4b2f-9466-65cc05f05ff9)

# Implemented changes

1. Added `interp1(..., fill_value=0)` for `p_lh`, `p_icrh`, and `p_rad` in `_get_power`. It should be safe to assume that these auxiliary heating powers were turned off during the periods where there were no data stored in the tree.
2. Added a try-except block in `get_ohmic_parameters` to return `nans` for `v_loop` and `p_ohm`. 
3. *Modified `_get_power` so that the `p_input` and `radiated_fraction` computations will take `p_ohm=0` even if `get_ohmic_parameters` fails.
    - `p_ohm` and `v_loop` should not be 0 even if there's no data stored in that node in a shot. I want to see there's a better way to do this (see TODO below)
    - This does not affect disruption-py's outputs for these two signals. They will still be arrays of nans when `get_ohmic_parameters` fails.

(Before -- dev)
![image](https://github.com/user-attachments/assets/f74a2ee7-d7d3-4090-979b-c33cc573b72d)

(After)
![image](https://github.com/user-attachments/assets/ec58147b-cf99-4761-8fa3-11e2cfb967c3)


# TODO

- [x] Should we switch to using `\efit_aeqdsk:vloopt` (i.e. `v_loop_efit`), or to use it as a backup in case there's no data stored in `mflux:v0`? @crea-psfc 
- [x] Check error catching.
- [x] Add `tau_rad` from ONW_DEV modules to the `get_power` method.

# Related PR(s)

- #344 
