### PR TITLE
Get physics method names

### DIFF
--- a/disruption_py/workflow.py
+++ b/disruption_py/workflow.py
@@ -12,6 +12,7 @@ from typing import Any, Callable
 from loguru import logger
 from tqdm.auto import tqdm
 
+from disruption_py.core.physics_method.runner import get_all_physics_methods
 from disruption_py.core.retrieval_manager import RetrievalManager
 from disruption_py.core.utils.misc import (
     get_elapsed_time,
@@ -20,6 +21,7 @@ from disruption_py.core.utils.misc import (
 )
 from disruption_py.inout.mds import ProcessMDSConnection
 from disruption_py.inout.sql import ShotDatabase
+from disruption_py.machine.method_holders import get_method_holders
 from disruption_py.machine.tokamak import Tokamak, resolve_tokamak_from_environment
 from disruption_py.settings import RetrievalSettings
 from disruption_py.settings.log_settings import LogSettings, resolve_log_settings
@@ -220,3 +222,25 @@ def _get_mds_instance(tokamak, mds_connection_initializer):
     if mds_connection_initializer:
         return mds_connection_initializer()
     return get_mdsplus_class(tokamak)
+
+
+def get_physics_method_names(tokamak: Tokamak = None) -> list[str]:
+    """
+    Get the names of all physics methods available for the tokamak.
+
+    Params
+    ------
+    tokamak : Tokamak
+        The tokamak to get the physics methods for. If None, the tokamak is resolved
+        from the environment.
+
+    Returns
+    -------
+    List[str]
+        The names of all physics methods available for the tokamak.
+    """
+    tokamak = resolve_tokamak_from_environment(tokamak)
+    method_holder = get_method_holders(tokamak)
+    all_physics_methods = get_all_physics_methods(method_holder)
+    method_names = [method.__name__ for method in all_physics_methods]
+    return method_names


### PR DESCRIPTION
Addresses 
- #346 

Adds a method to get the list of physics methods to make is easier to remove the ones we do not want.

Example:
```python
from disruption_py.settings.retrieval_settings import RetrievalSettings
from disruption_py.workflow import get_shots_data, get_physics_method_names

# E.g. retrieve data for everything except get_peaking_factors and get_ts_parameters
method_names = get_physics_method_names()
exclude = ["get_peaking_factors", "get_ts_parameters"]
methods_to_run = [m for m in method_names if m not in exclude]

retrieval_settings = RetrievalSettings(
    run_tags=[],
    run_methods=methods_to_run,
)
shot_data = get_shots_data(
    tokamak="cmod",
    shotlist_setting=[1150805012, 1150805013, 1150805014],
    retrieval_settings=retrieval_settings,
)
```
EDIT by GLT: removed a couple of unnecessary params from snippet.