### PR TITLE
Fix logs for MDSplus tree opening

### DIFF
--- a/disruption_py/inout/mds.py
+++ b/disruption_py/inout/mds.py
@@ -108,7 +108,6 @@ class MDSConnection:
         If the specified tree_name is a nickname for a tree_name, will open the tree
         that it is a nickname for.
         """
-        logger.trace("Opening tree: {tree_name}", tree_name=tree_name)
         if (
             tree_name not in self.tree_nicknames
             and tree_name in self.tree_nickname_funcs
@@ -119,6 +118,7 @@ class MDSConnection:
             tree_name = self.tree_nicknames[tree_name]
 
         if self.last_open_tree != tree_name:
+            logger.trace("Opening tree: {tree_name}", tree_name=tree_name)
             self.conn.openTree(tree_name, self.shot_id)
 
         self.last_open_tree = tree_name


### PR DESCRIPTION
## Problem
The trace logs are cluttered with redundant opening tree logs because previously we logged whenever the `open_tree` method of `MDSConnection` was called, even when we did not open a new connection.

## Proposed solution
Clean up the logs by only logging when we open a new tree with `self.conn.openTree(tree_name, self.shot_id)`. This also means we now log the MDS tree name rather than a nickname.

Previously:
![image](https://github.com/user-attachments/assets/fb4bca1a-1580-4c23-8200-46b8639d1b7c)

Now:
![image](https://github.com/user-attachments/assets/feb6e678-be4e-491c-8ba4-fbb541f901dd)

## Unchanged
We also have multiple database initialization logs even when there is only one shot. We pass a database instance to the `ShotlistSettingParams` in case someone wants to use an SQL query to get the shotlist. 

```
07:35:16.301 [ DEBUG ] Database initialization: decker@alcdb2/logbook
07:35:16.334 [ INFO  ] Starting workflow: 1 shot / 1 process
07:35:16.343 [ DEBUG ] Database initialization: decker@alcdb2/logbook     
```
The database initializer is lazy, so when we initialize the database we do not create a new connection. We log new connections separately. 

