### PR TITLE
Pin GH actions runner to ubuntu 22

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
       github.event_name == 'push' ||
       github.event_name == 'release' ||
       github.event.pull_request.draft == false
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
 
       - name: Checkout

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,7 +26,7 @@ concurrency:
 jobs:
 
   docs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: |
       github.event_name == 'push' ||
       github.event.pull_request.draft == false
@@ -60,7 +60,7 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: docs
     steps:
       - name: Deploy to GitHub Pages

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ jobs:
 
 
   black:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: |
       github.event_name == 'push' ||
       github.event.pull_request.draft == false
@@ -43,7 +43,7 @@ jobs:
 
 
   pylint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: |
       github.event_name == 'push' ||
       github.event.pull_request.draft == false
@@ -68,7 +68,7 @@ jobs:
 
 
   ruff:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: |
       github.event_name == 'push' ||
       github.event.pull_request.draft == false
@@ -93,7 +93,7 @@ jobs:
 
 
   shellcheck:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: |
       github.event_name == 'push' ||
       github.event.pull_request.draft == false
@@ -109,7 +109,7 @@ jobs:
 
 
   yamllint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: |
       github.event_name == 'push' ||
       github.event.pull_request.draft == false

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   stale:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/stale@v9
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
 
 
   pytest:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: |
       github.event_name == 'push' ||
       github.event.pull_request.draft == false


### PR DESCRIPTION
pin Github Actions runner to ubuntu 22 for now.