### PR TITLE
Do not raise C-MOD runtime warnings to errors

### DIFF
--- a/disruption_py/machine/cmod/physics.py
+++ b/disruption_py/machine/cmod/physics.py
@@ -22,8 +22,6 @@ from disruption_py.core.utils.math import (
 from disruption_py.machine.cmod.thomson import CmodThomsonDensityMeasure
 from disruption_py.machine.tokamak import Tokamak
 
-warnings.filterwarnings("error", category=RuntimeWarning)
-
 
 class CmodPhysicsMethods:
     """


### PR DESCRIPTION
RuntimeWarnings should probably we handled by each physics method.

close:
- #184 