### PR TITLE
Python test improvements

### DIFF
--- a/tests/test_against_cache.py
+++ b/tests/test_against_cache.py
@@ -136,6 +136,7 @@ def main():
 
     parser = argparse.ArgumentParser()
     parser.add_argument(
+        "-c",
         "--data-column",
         type=str.lower,
         default=None,
@@ -143,11 +144,21 @@ def main():
     )
 
     parser.add_argument(
+        "-s",
         "--shot-id",
         type=int,
         action="store",
         default=None,
         help="Shot number to test, uses the default shot list if not specified",
+    )
+
+    parser.add_argument(
+        "-l",
+        "--log-level",
+        type=str.lower,
+        action="store",
+        default="DEBUG",
+        help="Console log level",
     )
 
     args = parser.parse_args()
@@ -167,6 +178,7 @@ def main():
         shotlist=shotlist,
         expected_failure_columns=expected_failure_columns,
         test_columns=data_columns,
+        console_log_level=args.log_level,
     )
 
     columns = {dd.data_column for dd in data_differences}

--- a/tests/test_against_cache.py
+++ b/tests/test_against_cache.py
@@ -157,7 +157,7 @@ def main():
         "--log-level",
         type=str.lower,
         action="store",
-        default="DEBUG",
+        default="INFO",
         help="Console log level",
     )
 

--- a/tests/utils/eval_against_sql.py
+++ b/tests/utils/eval_against_sql.py
@@ -26,11 +26,25 @@ def get_fresh_data(
     shotlist: List[int],
     log_file_path: str,
     test_columns: List[str] = None,
+    console_log_level: str = "WARNING",
 ) -> Dict[int, pd.DataFrame]:
     """
     Get fresh data for a list of shots.
 
-     Returns
+    Parameters
+    ----------
+    tokamak : Tokamak
+        The tokamak for which to retrieve data.
+    shotlist : List[int]
+        A list of shot IDs to retrieve data for.
+    log_file_path : str
+        The path to the log file.
+    test_columns : List[str], optional
+        A list of columns to retrieve.
+    console_log_level : str, optional
+        The log level for console output. Default is "WARNING".
+
+    Returns
     -------
     Dict[int, pd.DataFrame]
         Dictionary mapping shot IDs to retrieved fresh data.
@@ -52,7 +66,7 @@ def get_fresh_data(
             log_file_path=log_file_path,
             log_file_write_mode="w",
             file_log_level="DEBUG",
-            console_log_level="WARNING",
+            console_log_level=console_log_level,
         ),
     )
     return shot_data
@@ -181,6 +195,7 @@ def eval_against_cache(
     shotlist: List[int],
     expected_failure_columns: List[str],
     test_columns=None,
+    console_log_level="WARNING",
 ) -> Dict[int, pd.DataFrame]:
     """
     Evaluate fresh data against cached data for specified shots.
@@ -200,6 +215,8 @@ def eval_against_cache(
     test_columns : List[str], optional
         A list of columns to test against the cached data. If None, the function
         will determine the columns based on the available data.
+    console_log_level : str, optional
+        The log level for console output. Default is "WARNING".
 
     Returns
     -------
@@ -226,6 +243,7 @@ def eval_against_cache(
             shotlist=shotlist,
             log_file_path=os.path.join(tempfolder, "data_retrieval.log"),
             test_columns=test_columns,
+            console_log_level=console_log_level,
         )
     cache_data = get_cached_from_fresh(tokamak, shotlist, fresh_data, test_columns)
 

--- a/tests/utils/eval_against_sql.py
+++ b/tests/utils/eval_against_sql.py
@@ -183,9 +183,10 @@ def eval_shot_against_cache(
     # Pytest should assert for expected failures to confirm the test fails or
     # to catch unexpected successes
     if "PYTEST_CURRENT_TEST" in os.environ or not expect_failure:
-        assert (
-            not data_difference.failed
-        ), f"Comparison failed on shot {data_difference.shot_id}, column {data_difference.data_column}"
+        assert not data_difference.failed, (
+            f"Comparison failed on shot {data_difference.shot_id}, "
+            "column {data_difference.data_column}"
+        )
 
     return data_difference
 

--- a/tests/utils/eval_against_sql.py
+++ b/tests/utils/eval_against_sql.py
@@ -18,6 +18,7 @@ from disruption_py.machine.tokamak import Tokamak
 from disruption_py.settings import LogSettings, RetrievalSettings
 from disruption_py.workflow import get_shots_data
 from tests.utils.data_difference import DataDifference
+from tests.utils.factory import get_tokamak_test_columns
 
 
 def get_fresh_data(
@@ -223,15 +224,7 @@ def eval_against_cache(
     cache_data = get_cached_from_fresh(tokamak, shotlist, fresh_data, test_columns)
 
     if test_columns is None:
-        fresh_columns = set().union(*(df.columns for df in fresh_data.values()))
-        cache_columns = set().union(*(df.columns for df in cache_data.values()))
-        # Handle when one of fresh/cache has no data
-        if len(fresh_columns) == 0:
-            test_columns = sorted(cache_columns)
-        elif len(cache_columns) == 0:
-            test_columns = sorted(fresh_columns)
-        else:
-            test_columns = sorted(fresh_columns.intersection(cache_columns))
+        test_columns = get_tokamak_test_columns(tokamak)
 
     data_differences = eval_shots_against_cache(
         shotlist=shotlist,

--- a/tests/utils/eval_against_sql.py
+++ b/tests/utils/eval_against_sql.py
@@ -165,7 +165,13 @@ def eval_shot_against_cache(
             failure=failure,
             mismatch_string=data_difference.column_mismatch_string,
         )
-    assert not data_difference.failed, "Comparison failed"
+    # Python tests should not assert for expected failures to only catch unexpected failures
+    # Pytest should assert for expected failures to confirm the test fails or
+    # to catch unexpected successes
+    if "PYTEST_CURRENT_TEST" in os.environ or not expect_failure:
+        assert (
+            not data_difference.failed
+        ), f"Comparison failed on shot {data_difference.shot_id}, column {data_difference.data_column}"
 
     return data_difference
 


### PR DESCRIPTION
## Addresses
-  https://github.com/MIT-PSFC/disruption-py/issues/376

## Changes
- Python test does not fail on expected failures
- Python test console log level is now "INFO" by default, but it can be changed from the console [EDIT by GLT]
```
python tests/test_against_cache.py -l warning
```
- Assertion now gives shot and column of failure e.g. `AssertionError: Comparison failed on shot 1150805012, column sxr`