### PR TITLE
Fix BatchedCSVOutputSetting

### DIFF
--- a/disruption_py/settings/output_setting.py
+++ b/disruption_py/settings/output_setting.py
@@ -595,6 +595,7 @@ class BatchedCSVOutputSetting(OutputSetting):
             os.remove(filepath)
 
         self.results: pd.DataFrame = pd.DataFrame()
+        self.columns = None
 
     def _output_shot(self, params: OutputSettingParams):
         """
@@ -606,6 +607,9 @@ class BatchedCSVOutputSetting(OutputSetting):
         params : OutputSettingParams
             The parameters containing the result to be outputted.
         """
+        if self.output_shot_count == 0:
+            self.columns = params.result.columns
+
         # Append the current result to the batch data list
         self.batch_data.append(params.result)
 
@@ -622,6 +626,8 @@ class BatchedCSVOutputSetting(OutputSetting):
         """
         file_exists = os.path.isfile(self.filepath)
         combined_df = safe_df_concat(pd.DataFrame(), self.batch_data)
+        # Enforce the to-be-saved combined_df to have the same column order as the first shot
+        combined_df = combined_df[self.columns]
         combined_df.to_csv(
             self.filepath, mode="a", index=False, header=(not file_exists)
         )

--- a/disruption_py/settings/output_setting.py
+++ b/disruption_py/settings/output_setting.py
@@ -607,9 +607,6 @@ class BatchedCSVOutputSetting(OutputSetting):
         params : OutputSettingParams
             The parameters containing the result to be outputted.
         """
-        # if self.output_shot_count == 0:
-        #     self.columns = params.result.columns
-
         # Append the current result to the batch data list
         self.batch_data.append(params.result)
 

--- a/disruption_py/settings/output_setting.py
+++ b/disruption_py/settings/output_setting.py
@@ -607,8 +607,8 @@ class BatchedCSVOutputSetting(OutputSetting):
         params : OutputSettingParams
             The parameters containing the result to be outputted.
         """
-        if self.output_shot_count == 0:
-            self.columns = params.result.columns
+        # if self.output_shot_count == 0:
+        #     self.columns = params.result.columns
 
         # Append the current result to the batch data list
         self.batch_data.append(params.result)
@@ -627,6 +627,8 @@ class BatchedCSVOutputSetting(OutputSetting):
         file_exists = os.path.isfile(self.filepath)
         combined_df = safe_df_concat(pd.DataFrame(), self.batch_data)
         # Enforce the to-be-saved combined_df to have the same column order as the first shot
+        if self.columns is None:
+            self.columns = combined_df.columns
         combined_df = combined_df[self.columns]
         combined_df.to_csv(
             self.filepath, mode="a", index=False, header=(not file_exists)

--- a/tests/test_output_setting.py
+++ b/tests/test_output_setting.py
@@ -135,3 +135,20 @@ def test_sql_output_setting(
     assert_frame_equal_unordered(
         result[ALL_ITERATION_COLUMNS], shot_data[ALL_ITERATION_COLUMNS]
     )
+
+
+@skip_on_fast_execution
+def test_batch_csv(tokamak, test_file_path_f):
+    """
+    Test the batch csv output setting to ensure it outputs the same columns in
+    the same order as the dataframe in memory.
+    """
+    csv = test_file_path_f(".csv")
+    out = get_shots_data(
+        tokamak=tokamak,
+        shotlist_setting="disruption_py/data/cmod_ufo.csv",
+        num_processes=10,
+        output_setting=csv,
+    )
+    df = pd.read_csv(csv)
+    assert_frame_equal_unordered(out, df)


### PR DESCRIPTION
# Original problem

- #382

# Analysis of the problem

- `get_shot_data` does not always return shot data in the same order of columns (i.e. shot 1 may have columns in [A, B, C] order whereas shot 2 may have them in [B, C, A]). When saving data, `BatchedCSVOutputSetting` does not check the order before appending the new shot data to an existing csv file. This may cause some signals to be appended to the wrong columns, which causes the mismatch error identified in the Issue.

# Implemented changes

- Record the columns of the first batch as `self.columns`.
- Enforce all future batch dataframe to have the same order of columns as `self.columns` before being saved to file. 

# Test case (use the current `dev` version)

```
from disruption_py.settings import LogSettings, RetrievalSettings
from disruption_py.workflow import get_shots_data
import numpy as np
import pandas as pd
import os
shotlist = [
            1160405017, 1160412004, 1160412021, 1160412028, 1160412031, 1160413005, 1160415006, 1160415011, 1160415016, 1160415023,
            1160415025, 1160415030, 1160427016, 1160503007, 1160503009, 1160503011, 1160503015, 1160503020, 1160503023, 1160503026,
            1160503027, 1160504006, 1160504007, 1160504009, 1160504010, 1160504012, 1160505018, 1160506005, 1160506016, 1160511003,
            1160511006, 1160511007, 1160511008, 1160511009, 1160511011, 1160511012, 1160511013, 1160511014, 1160511015, 1160511016,
            1160511017, 1160511018, 1160511019, 1160511020, 1160511022, 1160511023, 1160511025, 1160511027, 1160512001, 1160512002,
            1160512003, 1160512004, 1160512005, 1160512006, 1160512007, 1160512008, 1160512016, 1160512020, 1160512023, 1160512027,
            1160512030, 1160512032, 1160513004, 1160513005, 1160513006, 1160513007, 1160513008, 1160513009, 1160513010, 1160513012,
            1160513013, 1160513014, 1160513015, 1160513016, 1160513017, 1160513019, 1160513020, 1160513022, 1160513027, 1160520006,
            1160520018, 1160525006, 1160525019, 1160607003, 1160607018, 1160607026, 1160607030, 1160607031, 1160608008, 1160608015,
            1160608017, 1160609002, 1160609005, 1160609013, 1160609026, 1160609027, 1160615010, 1160615019, 1160615023, 1160617008,
            1160617015, 1160617016, 1160617018, 1160617021, 1160617022, 1160617027, 1160617033, 1160617034, 1160621003, 1160628002,
            1160628003, 1160628004, 1160628005, 1160628006, 1160628007, 1160628008, 1160706001, 1160707001, 1160707002, 1160707003,
            1160707004, 1160707005, 1160707006, 1160707007, 1160707008, 1160707009, 1160707010, 1160707011, 1160707012, 1160707013,
            1160707014, 1160707015, 1160708011, 1160708015, 1160708021, 1160712003, 1160712006, 1160712012, 1160712018, 1160713015,
            1160714006, 1160714013, 1160714017, 1160714025, 1160714027, 1160714033, 1160718013, 1160720012, 1160720019, 1160720021,
            1160721012, 1160721020, 1160722007, 1160722008, 1160725019, 1160725026, 1160728002, 1160728004, 1160728013, 1160728021,
            1160728022, 1160728023, 1160729018, 1160803023, 1160803028, 1160803029, 1160803030, 1160803035, 1160804012, 1160804025,
            1160804029, 1160805001, 1160805006, 1160805017, 1160809004, 1160809012, 1160809014, 1160810004, 1160810009, 1160811011,
            1160811013, 1160811015, 1160816006, 1160816009, 1160816017, 1160816018, 1160816019, 1160816020, 1160816025, 1160816026,
            1160817002, 1160817009, 1160818017, 1160819006, 1160819008, 1160823006, 1160823007, 1160823019, 1160824002, 1160824003,
            1160824004, 1160824005, 1160824011, 1160824012, 1160824013, 1160824019, 1160824024, 1160825001, 1160826007, 1160826009,
            1160826022, 1160826024, 1160826028, 1160831016, 1160831018, 1160901007, 1160901013, 1160901017, 1160902007, 1160902013,
            1160902019, 1160907004, 1160907007, 1160907011, 1160907014, 1160908010, 1160908012, 1160908014, 1160908018, 1160908020,
            1160908021, 1160909025, 1160909026, 1160915015, 1160915021, 1160916007, 1160916008, 1160920023, 1160921016, 1160922001,
            1160922018, 1160922020, 1160922022, 1160922025, 1160922027, 1160922029, 1160922032, 1160923006, 1160923016, 1160923025,
            1160926032, 1160928010, 1160928020, 1160929001, 1160929004, 1160929007, 1160929008, 1160929009, 1160929027, 1160929028,
            1160929030, 1160930009, 1160930011, 1160930015, 1160930023, 1160930025, 1160930030, 1160930034, 1160930038, 1160930039,
            ]

# Get flattop shots data
retrieval_settings = RetrievalSettings(
    efit_nickname_setting = "disruption",
    time_setting = "disruption_warning",
    domain_setting = 'flattop',
)
ram_df = get_shots_data(
    shotlist_setting = shotlist,
    tokamak = "cmod",
    retrieval_settings = retrieval_settings,
    output_setting = "dumped_data_v2.csv",
    num_processes = 20,
    log_settings=LogSettings(  # logging
        log_file_path=None,  # Defaults to "output.log" in the tmp folder for the session
        file_log_level="SUCCESS",
        log_file_write_mode="w",
        log_to_console=True,
        use_custom_logging=False,
    )
)
dumped_df = pd.read_csv('dumped_data_v2.csv')
columns = ram_df.columns
columns = columns.drop('commit_hash')
dfs_match=np.isclose(ram_df[columns], dumped_df[columns], equal_nan=True).all()
print(f'ram_df matches dumped_df: {dfs_match}')
if not dfs_match:
    mismatch_columns = columns[np.isclose(ram_df[columns], dumped_df[columns], equal_nan=True).all(axis=0)==False].to_list()
    mismatch_rows = np.isclose(ram_df[columns], dumped_df[columns], equal_nan=True).all(axis=1)==False
    print(f'mismatched columns: {mismatch_columns}')
    a = ram_df.iloc[mismatch_rows][['shot', 'time']+mismatch_columns]
    b = dumped_df.iloc[mismatch_rows][['shot', 'time']+mismatch_columns]
    comparison = a.compare(b, keep_shape=True, keep_equal=True)
    print('Mismatched columns:')
    print(comparison)
    print('Mismatched shotlist:')
    print(comparison['shot']['self'].unique())
    print(f"{len(comparison['shot']['self'].unique())} shots")
    print('shotno list in dumped_df in the fetched order:')
    print(f"{dumped_df['shot'].unique()}")
os.remove('dumped_data_v2.csv')
```