### PR TITLE
Log physics method time in decorator

### DIFF
--- a/disruption_py/core/physics_method/decorator.py
+++ b/disruption_py/core/physics_method/decorator.py
@@ -5,6 +5,7 @@ This module provides a decorator to signify methods that calculate physics quant
 """
 
 import time
+from functools import wraps
 from typing import Callable, List, Union
 
 from disruption_py.core.physics_method.caching import cache_method
@@ -56,6 +57,7 @@ def physics_method(
             wrapper = method
 
         # Add elapsed time log
+        @wraps(wrapper)
         def timed_wrapper(params, *args, **kwargs):
             start_time = time.time()
             result = wrapper(params, *args, **kwargs)

--- a/disruption_py/core/physics_method/decorator.py
+++ b/disruption_py/core/physics_method/decorator.py
@@ -4,6 +4,7 @@
 This module provides a decorator to signify methods that calculate physics quantities.
 """
 
+import time
 from typing import Callable, List, Union
 
 from disruption_py.core.physics_method.caching import cache_method
@@ -54,6 +55,17 @@ def physics_method(
         else:
             wrapper = method
 
+        # Add elapsed time log
+        def timed_wrapper(params, *args, **kwargs):
+            start_time = time.time()
+            result = wrapper(params, *args, **kwargs)
+            params.logger.verbose(
+                "{t:.3f}s : {name}",
+                name=method.__name__,
+                t=time.time() - start_time,
+            )
+            return result
+
         method_metadata = MethodMetadata(
             name=method.__name__,
             cache=cache,
@@ -61,7 +73,8 @@ def physics_method(
             columns=columns,
         )
 
-        wrapper.method_metadata = method_metadata
-        return wrapper
+        timed_wrapper.method_metadata = method_metadata
+
+        return timed_wrapper
 
     return outer_wrapper

--- a/disruption_py/core/physics_method/runner.py
+++ b/disruption_py/core/physics_method/runner.py
@@ -221,7 +221,6 @@ def populate_method(
     Any
         The result of the executed method, or None if an error occurred.
     """
-    start_time = time.time()
     method = bound_method_metadata.bound_method
     name = bound_method_metadata.name
 
@@ -253,11 +252,6 @@ def populate_method(
         physics_method_params.logger.opt(exception=True).debug(e)
         result = {col: [np.nan] for col in bound_method_metadata.columns}
 
-    physics_method_params.logger.verbose(
-        "{t:.3f}s : {name}",
-        name=name,
-        t=time.time() - start_time,
-    )
     return result
 
 


### PR DESCRIPTION
## Problem
As discussed in 
- https://github.com/MIT-PSFC/disruption-py/pull/368#issuecomment-2606837596

Some physics methods are called by others (e.g. `get_ohmic_parameters` calls `get_ip_parameters`) but the time taken for the inner calls are not logged.


## Proposed solution
Do not log in `runner.py` for each collected method, but instead in the `physics_method` decorator so all physics methods, regardless of how they are called, get logged.

## Verification
```
python examples/simple.py -m get_ohmic_parameters
```
Now logs both methods. 

![image](https://github.com/user-attachments/assets/da7b746f-fece-4271-ac83-3e5cc5abcc06)



