### PR TITLE
Remove dipprog_dt_rt from DIII-D XFAIL column

### DIFF
--- a/disruption_py/machine/d3d/config.toml
+++ b/disruption_py/machine/d3d/config.toml
@@ -17,7 +17,6 @@ expected_failure_columns = [
   "commit_hash",
   "dbetap_dt",
   "delta",
-  "dipprog_dt_rt",
   "dli_dt",
   "dn_dt",
   "dwmhd_dt",


### PR DESCRIPTION
`test_data_columns[dipprog_dt_rt]` changed from `XFAIL` to `XPASS` following #364 Cast data to float64 by default. Remove it from the XFAIL column.