### PR TITLE
Fix measurement of test times

### DIFF
--- a/tests/test_against_cache.py
+++ b/tests/test_against_cache.py
@@ -107,6 +107,18 @@ def cache_data_fixture(
     return cache_data
 
 
+def test_data_fetch(
+    shotlist: List[int],
+    fresh_data: Dict[int, pd.DataFrame],
+    cache_data: Dict[int, pd.DataFrame],
+    expected_failure_columns: List[str],
+):
+    """
+    Convenience test that triggers some fixtures to get more accurate time measurements.
+    """
+    return shotlist, fresh_data, cache_data, expected_failure_columns
+
+
 def test_data_columns(
     shotlist: List[int],
     fresh_data: Dict[int, pd.DataFrame],


### PR DESCRIPTION
add a simple wrapper test with the only purpose of triggering the pytest fixtures so that time spent eg collecting data will be assigned to this test.
as a consequence, test_data_columns -- or, more precisely, the first parameterized data column test -- should drop from being one of the slowest tests to being as fast as the others.

ideally, we should have similar wrappers in other test files in order to better diagnostic drastic slowdowns in test execution.

returning data to avoid the unused variable linter error.