### PR TITLE
Improve C-MOD Te width computation

### DIFF
--- a/disruption_py/core/utils/math.py
+++ b/disruption_py/core/utils/math.py
@@ -185,7 +185,7 @@ def gauss_smooth(y, smooth_width, ends_type):
 
 
 @filter_cov_warning
-def gaussian_fit(*args):
+def gaussian_fit(*args, **kwargs):
     """
     Fits a Gaussian curve to a set of data points (x,y).
     Returns an array of coefficients, c, that describe the fit.
@@ -206,7 +206,7 @@ def gaussian_fit(*args):
     coeffs : array
         The coefficients of the fit.
     """
-    coeffs, *_ = curve_fit(gauss, *args)
+    coeffs, *_ = curve_fit(gauss, *args, **kwargs)
     return coeffs
 
 

--- a/disruption_py/machine/cmod/physics.py
+++ b/disruption_py/machine/cmod/physics.py
@@ -1051,14 +1051,14 @@ class CmodPhysicsMethods:
                 if str(exc).startswith("Optimal parameters not found"):
                     continue
                 raise exc
-            # reject points with unphysical mean or sigma
-            if pmean < -0.35 or pmean > 0.35 or psigma > 0.35:
+            # rescale from sigma to HWHM
+            # https://en.wikipedia.org/wiki/Full_width_at_half_maximum
+            hwm = np.abs(psigma) * np.sqrt(2 * np.log(2))
+            # reject points with unphysical mean or hwm
+            if pmean < -0.35 or pmean > 0.35 or hwm > 0.35:
                 continue
             # store output
-            te_hwm[idx] = np.abs(psigma)
-        # rescale from sigma to HWHM
-        # https://en.wikipedia.org/wiki/Full_width_at_half_maximum
-        te_hwm *= np.sqrt(2 * np.log(2))
+            te_hwm[idx] = hwm
         # time interpolation
         te_hwm = interp1(ts_time, te_hwm, times)
         return {"te_width": te_hwm}

--- a/disruption_py/machine/cmod/physics.py
+++ b/disruption_py/machine/cmod/physics.py
@@ -1053,14 +1053,17 @@ class CmodPhysicsMethods:
                 if str(exc).startswith("Optimal parameters not found"):
                     continue
                 raise exc
-            # rescale from sigma to HWHM
-            # https://en.wikipedia.org/wiki/Full_width_at_half_maximum
-            hwm = np.abs(psigma) * np.sqrt(2 * np.log(2))
-            # reject points with unphysical mean or hwm
-            if pmean < -0.35 or pmean > 0.35 or hwm > 0.35:
+            # reject points with unphysical mean
+            if pmean < -0.35 or pmean > 0.35:
                 continue
             # store output
-            te_hwm[idx] = hwm
+            te_hwm[idx] = np.abs(psigma)
+        # rescale from sigma to HWHM
+        # https://en.wikipedia.org/wiki/Full_width_at_half_maximum
+        te_hwm *= np.sqrt(2 * np.log(2))
+        # reject points with unphysical HWHM
+        (bad_indices,) = np.where(te_hwm > 0.35)
+        te_hwm[bad_indices] = np.nan
         # time interpolation
         te_hwm = interp1(ts_time, te_hwm, times)
         return {"te_width": te_hwm}

--- a/disruption_py/machine/cmod/physics.py
+++ b/disruption_py/machine/cmod/physics.py
@@ -1046,7 +1046,9 @@ class CmodPhysicsMethods:
             guess = [y[i], z[i], (z.max() - z.min()) / 3]
             # actual fit
             try:
-                _, pmean, psigma = gaussian_fit(z, y, guess, y_error, True)
+                _, pmean, psigma = gaussian_fit(
+                    z, y, guess, sigma=y_error, absolute_sigma=True
+                )
             except RuntimeError as exc:
                 if str(exc).startswith("Optimal parameters not found"):
                     continue


### PR DESCRIPTION
# Original problem
- #383 

# Analysis of the problem
- Several outer cords in TE_RZ appear to have spikes that shoot up to unreasonably large values. Jerry Hughes commented that these are likely caused by errors from the Thomson's hardware.
- To compensate these, Jerry recommends including the Te error (`TE_ERR`) in the gaussian fit. 

(1160615021)
![image](https://github.com/user-attachments/assets/e0cde426-e968-451b-b3bd-095a494debfe)

# Implemented changes

- Include `TE_ERR` as the uncertainty of the Te data points in `curve_fit`. Doing this alone resolves all of the identified problem. 
  - 1150805022 time [24] which is a previously identified bad fit is now automatically rejected as the fit couldn't converge.
- Check and reject unreasonable values of the fitted gaussian mean and HWHM.

# Sample outputs

![image](https://github.com/user-attachments/assets/57a6a3b6-62d3-476c-a5e4-6d75ef0b6c4a)
![image](https://github.com/user-attachments/assets/4317311f-31a8-4d46-92d7-f7df6b6a1fea)

