### PR TITLE
Specify commit_hash dtype in all pd.read_csv calls

### DIFF
--- a/disruption_py/settings/cache_setting.py
+++ b/disruption_py/settings/cache_setting.py
@@ -187,7 +187,7 @@ class CSVCacheSetting(CacheSetting):
         self.cache_file = cache_file
 
     def _get_cache_data(self, params: CacheSettingParams) -> pd.DataFrame:
-        return pd.read_csv(self.cache_file)
+        return pd.read_csv(self.cache_file, dtype={"commit_hash": str})
 
 
 # --8<-- [start:cache_setting_dict]

--- a/disruption_py/settings/output_setting.py
+++ b/disruption_py/settings/output_setting.py
@@ -525,7 +525,7 @@ class CSVOutputSetting(OutputSetting):
         file_exists = os.path.isfile(self.filepath)
         if self.flexible_columns:
             if file_exists:
-                existing_df = pd.read_csv(self.filepath)
+                existing_df = pd.read_csv(self.filepath, dtype={"commit_hash": str})
                 combined_df = safe_df_concat(existing_df, [params.result])
             else:
                 combined_df = params.result

--- a/disruption_py/settings/shotlist_setting.py
+++ b/disruption_py/settings/shotlist_setting.py
@@ -99,7 +99,7 @@ class FileShotlistSetting(ShotlistSetting):
     def _get_shotlist(self, params: ShotlistSettingParams) -> List:
         if not self.shotlist:
             self.kwargs.setdefault("header", "infer")
-            df = pd.read_csv(self.file_path, **self.kwargs)
+            df = pd.read_csv(self.file_path, dtype={"commit_hash": str}, **self.kwargs)
             arr = df.values[:, self.column_index]
             self.shotlist = arr.astype(int).tolist()
         return self.shotlist

--- a/tests/test_output_setting.py
+++ b/tests/test_output_setting.py
@@ -154,5 +154,5 @@ def test_batch_csv(tokamak, test_file_path_f, shotlist):
         # are written to the CSV file.
         output_setting=BatchedCSVOutputSetting(filepath=csv, batch_size=1),
     )
-    df = pd.read_csv(csv)
+    df = pd.read_csv(csv, dtype={"commit_hash": str})
     assert_frame_equal_unordered(out, df)


### PR DESCRIPTION
- Added `dtype={"commit_hash": str}` argument in all occurrence of `pd.read_csv` except those in the draft folder.
- The csv file dumped by disruption-py should always have the `commit_hash` column regardless of the retrieval settings, therefore I didn't add a statement to check if the column exist.