### PR TITLE
Improve CMOD ohmic power computation

### DIFF
--- a/disruption_py/core/utils/math.py
+++ b/disruption_py/core/utils/math.py
@@ -87,7 +87,7 @@ def interp1(x, y, new_x, kind="linear", bounds_error=False, fill_value=np.nan, a
     return set_interp(new_x)
 
 
-def smooth(arr: np.ndarray, window_size: int) -> np.ndarray:
+def matlab_smooth(arr: np.ndarray, window_size: int) -> np.ndarray:
     """
     Implements Matlab's smooth function https://www.mathworks.com/help/curvefit/smooth.html.
 
@@ -109,6 +109,28 @@ def smooth(arr: np.ndarray, window_size: int) -> np.ndarray:
     start = np.cumsum(arr[: window_size - 1][::2] / b_weights)
     end = (np.cumsum(arr[:-window_size:-1])[::2] / b_weights)[::-1]
     return np.concatenate((start, mid, end))
+
+
+def causal_boxcar_smooth(signal: np.array, window_size: int) -> np.ndarray:
+    """
+    Causal boxcar averaging filter
+    Parameters
+    ----------
+    signal: np.ndarray
+        Signal to smooth
+    window_size: int
+        Size of the window to smooth over
+    Returns
+    -------
+    np.ndarray
+        Smoothed array
+    """
+    kernel = np.ones(window_size) / window_size
+    mid = np.convolve(signal, kernel, mode="valid")
+    start = np.zeros(window_size - 1)
+    for i in range(window_size - 1):
+        start[i] = np.mean(signal[: i + 1])
+    return np.concatenate((start, mid))
 
 
 @filter_cov_warning

--- a/disruption_py/machine/cmod/config.toml
+++ b/disruption_py/machine/cmod/config.toml
@@ -76,6 +76,7 @@ expected_failure_columns = [
   "sxr",
   "te_peaking",
   "te_width",
+  "v_loop",
   "v_z",
   "z_times_v_z",
   "zcur",

--- a/disruption_py/machine/east/physics.py
+++ b/disruption_py/machine/east/physics.py
@@ -10,7 +10,7 @@ from MDSplus import mdsExceptions
 
 from disruption_py.core.physics_method.decorator import physics_method
 from disruption_py.core.physics_method.params import PhysicsMethodParams
-from disruption_py.core.utils.math import interp1, smooth
+from disruption_py.core.utils.math import interp1, matlab_smooth
 from disruption_py.machine.east.efit import EastEfitMethods
 from disruption_py.machine.east.util import EastUtilMethods
 from disruption_py.machine.tokamak import Tokamak
@@ -676,7 +676,7 @@ class EastPhysicsMethods:
         )  # [A]
         sign_ip = np.sign(sum(ip))
         dipdt = np.gradient(ip, ip_time)
-        dipdt_smoothed = smooth(dipdt, 11)  # Use 11-point boxcar smoothing
+        dipdt_smoothed = matlab_smooth(dipdt, 11)  # Use 11-point boxcar smoothing
 
         # Interpolate fetched signals to the requested timebase
         vloop = interp1(vloop_time, vloop, params.times, kind="linear", bounds_error=0)
@@ -1395,7 +1395,7 @@ class EastPhysicsMethods:
                     r"\pxuv" + str(ichord + 1), tree_name="east_1"
                 )
                 signal = signal - np.mean(signal[:100])  # Subtract baseline
-                signal_smoothed = smooth(signal, smoothing_window)
+                signal_smoothed = matlab_smooth(signal, smoothing_window)
                 xuv[:, ichord] = (
                     signal_smoothed
                     * fac_1[ichan]


### PR DESCRIPTION
# Previous discussion

- #406 

# Implemented changes

- Replace the boxcar smoothing function for calculating `dip_smoothed` with the newly added `causal_boxcar_smooth` function.
- Use the same `causal_boxcar_smooth` function to smooth the noisy `v_loop` signal (from `\analysis::top.mflux:v0`).
  - For both `dip_smoothed` and `v_loop` I use 6-point boxcar smoothing which introduces a delay of about 0.5 ms observed at the end of the shot (see figures in the issue). I believe this amount of delay is tolerable since we are going to rerun EFIT with 1 ms interval.
- Replace all negative values of the computed `p_oh` to 0.
  - This isn't the ideal approach. I have also considered removing these data points and interpolate them from the nearby points. However, the nearby points aren't necessarily reliable either especially prior to a disruption where we observe higher level of fluctuation in magnetic signals due to plasma dynamics or noise. To me this is unavoidable since we are inferring the ohmic power through measurements on the plasma instead of the central stack voltage -- perhaps @granetz can comment on this.

# Note

- <s>I have **not** removed the plotting functions for comparing the raw & filtered signals!</s> I have removed the plotting functions. The previous version with the plotting functions are now moved to a new branch called `wei/improve-get-ohmic-plotting`. @AlexSaperstein please take a look using a couple other shots and make sure the levels of noise and delay are acceptable.

# TODO: 

- [ ] 🚨rebase🚨 to `origin/dev` in order to modify the docstring.
- [ ] The previous (non-causal) `smooth` function is also used in the EAST branch. I'll update those methods in a separate PR.
