### PR TITLE
Fix non-git edge cases

### DIFF
--- a/disruption_py/settings/log_settings.py
+++ b/disruption_py/settings/log_settings.py
@@ -163,12 +163,13 @@ class LogSettings:
         self.reset_handlers(num_shots=None)
 
         # header
-        package = "disruption_py"
+        package, *_ = __name__.split(".")
         commit = get_commit_hash()
         logger.info(
-            "Starting: {p} ~ v{v} # {c} / {u}@{h}",
+            "Starting: {p} ~ v{v}{t}{c} / {u}@{h}",
             p=package,
             v=importlib.metadata.version(package),
+            t=" # " if commit else "",
             c=commit,
             u=os.getenv("USER"),
             h=os.uname().nodename,
@@ -176,9 +177,9 @@ class LogSettings:
         if self.log_file_path is not None:
             logger.info("Logging: {l}", l=self.log_file_path)
         logger.debug(
-            "Repository: {r}/commit/{c}",
-            r="https://github.com/MIT-PSFC/disruption-py",
-            c=commit,
+            "Repository: {url}/{append}",
+            url="https://github.com/MIT-PSFC/disruption-py",
+            append=f"commit/{commit}" if commit else "",
         )
         logger.debug("Executable: {e}", e=sys.executable)
 

--- a/disruption_py/settings/log_settings.py
+++ b/disruption_py/settings/log_settings.py
@@ -177,9 +177,10 @@ class LogSettings:
         if self.log_file_path is not None:
             logger.info("Logging: {l}", l=self.log_file_path)
         logger.debug(
-            "Repository: {url}/{append}",
+            "Repository: {url}{append}{commit}",
             url="https://github.com/MIT-PSFC/disruption-py",
-            append=f"commit/{commit}" if commit else "",
+            append="/commit/" if commit else "",
+            commit=commit,
         )
         logger.debug("Executable: {e}", e=sys.executable)
 

--- a/disruption_py/settings/retrieval_settings.py
+++ b/disruption_py/settings/retrieval_settings.py
@@ -16,10 +16,7 @@ from disruption_py.settings.nickname_setting import (
     NicknameSetting,
     resolve_nickname_setting,
 )
-from disruption_py.settings.time_setting import (
-    TimeSetting,
-    resolve_time_setting,
-)
+from disruption_py.settings.time_setting import TimeSetting, resolve_time_setting
 
 
 class InterpolationMethod(Enum):

--- a/disruption_py/workflow.py
+++ b/disruption_py/workflow.py
@@ -124,7 +124,7 @@ def get_shots_data(
     num_processes = min(num_processes, len(shotlist_list))
     if num_processes < 1:
         logger.critical("Nothing to do!")
-        return
+        return None
 
     # Dynamically set the console log level based on the number of shots
     if log_settings.console_log_level is None:

--- a/disruption_py/workflow.py
+++ b/disruption_py/workflow.py
@@ -122,6 +122,9 @@ def get_shots_data(
         shotlist_setting_runner(shotlist_setting, shotlist_setting_params)
     )
     num_processes = min(num_processes, len(shotlist_list))
+    if num_processes < 1:
+        logger.critical("Nothing to do!")
+        return
 
     # Dynamically set the console log level based on the number of shots
     if log_settings.console_log_level is None:

--- a/disruption_py/workflow.py
+++ b/disruption_py/workflow.py
@@ -14,6 +14,7 @@ from typing import Any, Callable
 from loguru import logger
 from tqdm.auto import tqdm
 
+from disruption_py.config import config
 from disruption_py.core.retrieval_manager import RetrievalManager
 from disruption_py.core.utils.misc import (
     get_elapsed_time,
@@ -37,7 +38,6 @@ from disruption_py.settings.shotlist_setting import (
     ShotlistSettingType,
     shotlist_setting_runner,
 )
-from tests.utils.factory import get_tokamak_test_shotlist
 
 
 def _execute_retrieval(args):
@@ -235,7 +235,7 @@ def run(
     if not tokamak:
         tokamak = resolve_tokamak_from_environment()
     if not shots:
-        shots, *_ = get_tokamak_test_shotlist(tokamak)
+        shots, *_ = config(tokamak).tests.shots.values()
     methods = methods or None
 
     sett = RetrievalSettings(


### PR DESCRIPTION
- make the log header more resilient to non-git runs
- avoid importing the `tests` module which is unavailable for non-git installs
- log critical error if no shots or no processors