### PR TITLE
More robust shot data retrieval

### DIFF
--- a/disruption_py/core/physics_method/runner.py
+++ b/disruption_py/core/physics_method/runner.py
@@ -184,12 +184,15 @@ def populate_method(
     # pylint: disable-next=broad-exception-caught
     except Exception as e:
         level = "ERROR"
-        if isinstance(e, (mdsExceptions.MdsException, CalculationError)):
-            if not isinstance(e, mdsExceptions.MDSplusERROR):
-                level = "WARNING"
+        if isinstance(e, mdsExceptions.MDSplusERROR):
+            pass
+        elif isinstance(e, (mdsExceptions.MdsException, CalculationError)):
+            level = "WARNING"
         physics_method_params.logger.log(level, "{name}: {exc}", name=name, exc=repr(e))
         physics_method_params.logger.opt(exception=True).debug(name)
         result = {col: [np.nan] for col in bound_method_metadata.columns}
+        if isinstance(e, mdsExceptions.MDSplusERROR):
+            physics_method_params.mds_conn.reconnect()
 
     return result
 

--- a/disruption_py/core/retrieval_manager.py
+++ b/disruption_py/core/retrieval_manager.py
@@ -115,6 +115,7 @@ class RetrievalManager:
         except Exception as e:
             logger.critical(shot_msg("Failed cleanup! {e}"), shot=shot_id, e=repr(e))
             logger.opt(exception=True).debug(shot_msg("Failed cleanup!"), shot=shot_id)
+            retrieved_data = None
             logger.debug(
                 "PID #{pid} | Reconnecting to MDSplus server.",
                 pid=threading.get_native_id(),

--- a/disruption_py/core/retrieval_manager.py
+++ b/disruption_py/core/retrieval_manager.py
@@ -79,7 +79,6 @@ class RetrievalManager:
         logger.trace(shot_msg("Starting retrieval."), shot=shot_id)
 
         # shot setup
-        physics_method_params = None
         try:
             physics_method_params = self.shot_setup(
                 shot_id=int(shot_id),
@@ -89,24 +88,22 @@ class RetrievalManager:
         except Exception as e:
             logger.critical(shot_msg("Failed setup! {e}"), shot=shot_id, e=repr(e))
             logger.opt(exception=True).debug(shot_msg("Failed setup!"), shot=shot_id)
+            return None
 
         # shot retrieval
-        retrieved_data = None
-        if physics_method_params:
-            try:
-                retrieved_data = populate_shot(
-                    retrieval_settings=retrieval_settings,
-                    physics_method_params=physics_method_params,
-                )
-            # pylint: disable-next=broad-exception-caught
-            except Exception as e:
-                # exceptions should be caught by runner.py
-                logger.critical(
-                    shot_msg("Failed retrieval! {e}"), shot=shot_id, e=repr(e)
-                )
-                logger.opt(exception=True).debug(
-                    shot_msg("Failed retrieval!"), shot=shot_id
-                )
+        try:
+            retrieved_data = populate_shot(
+                retrieval_settings=retrieval_settings,
+                physics_method_params=physics_method_params,
+            )
+        # pylint: disable-next=broad-exception-caught
+        except Exception as e:
+            # exceptions should be caught by runner.py
+            logger.critical(shot_msg("Failed retrieval! {e}"), shot=shot_id, e=repr(e))
+            logger.opt(exception=True).debug(
+                shot_msg("Failed retrieval!"), shot=shot_id
+            )
+            retrieved_data = None
 
         # shot cleanup
         try:

--- a/disruption_py/core/retrieval_manager.py
+++ b/disruption_py/core/retrieval_manager.py
@@ -5,8 +5,6 @@ Module for managing retrieval of shot data from a tokamak.
 """
 
 
-import threading
-
 import numpy as np
 import pandas as pd
 from loguru import logger
@@ -113,11 +111,7 @@ class RetrievalManager:
             logger.critical(shot_msg("Failed cleanup! {e}"), shot=shot_id, e=repr(e))
             logger.opt(exception=True).debug(shot_msg("Failed cleanup!"), shot=shot_id)
             retrieved_data = None
-            logger.debug(
-                "PID #{pid} | Reconnecting to MDSplus server.",
-                pid=threading.get_native_id(),
-            )
-            physics_method_params.mds_conn.conn.reconnect()
+            physics_method_params.mds_conn.reconnect()
 
         return retrieved_data
 

--- a/disruption_py/inout/mds.py
+++ b/disruption_py/inout/mds.py
@@ -4,6 +4,7 @@
 Module for managing connections to MDSplus.
 """
 
+import threading
 from typing import Any, Callable, Dict, List, Tuple
 
 import MDSplus
@@ -28,6 +29,11 @@ class ProcessMDSConnection:
         self.conn = None
         if conn_string is None:
             return
+        logger.debug(
+            "PID #{pid} | Connecting to MDSplus server: {server}",
+            server=conn_string,
+            pid=threading.get_native_id(),
+        )
         # pylint: disable=no-member
         self.conn = MDSplus.Connection(conn_string)
         try:

--- a/disruption_py/inout/mds.py
+++ b/disruption_py/inout/mds.py
@@ -108,6 +108,16 @@ class MDSConnection:
         self.tree_nicknames = {}
         self.last_open_tree = None
 
+    def reconnect(self):
+        """
+        Reconnect to the MDSplus server.
+        """
+        logger.debug(
+            "PID #{pid} | Reconnecting to MDSplus server.",
+            pid=threading.get_native_id(),
+        )
+        self.conn.reconnect()
+
     @_better_mds_exceptions
     def open_tree(self, tree_name: str):
         """

--- a/disruption_py/inout/mds.py
+++ b/disruption_py/inout/mds.py
@@ -89,7 +89,8 @@ def _better_mds_exceptions(func):
                 err = "Bad record"
             else:
                 err = "MDSplus error"
-            raise type(e)(f"{err}. Tree: {self.open_trees[0]}, Node: {path}") from None
+            last_tree = self.open_trees[0] if self.open_trees else None
+            raise type(e)(f"{err}. Tree: {last_tree}, Node: {path}") from None
 
     return wrapper
 

--- a/disruption_py/inout/mds.py
+++ b/disruption_py/inout/mds.py
@@ -139,10 +139,7 @@ class MDSConnection:
         """
         Close all open trees
         """
-        logger.trace(
-            shot_msg("Closing trees"),
-            shot=self.shot_id,
-        )
+        logger.trace(shot_msg("Closing trees"), shot=self.shot_id)
         self.conn.closeAllTrees()
         self.last_open_tree = None
 

--- a/disruption_py/inout/mds.py
+++ b/disruption_py/inout/mds.py
@@ -139,6 +139,11 @@ class MDSConnection:
         """
         Close all open trees
         """
+        logger.trace(
+            shot_msg("Closing trees"),
+            shot=self.shot_id,
+        )
+        self.conn.closeAllTrees()
         self.last_open_tree = None
 
     @_better_mds_exceptions

--- a/disruption_py/inout/mds.py
+++ b/disruption_py/inout/mds.py
@@ -118,6 +118,7 @@ class MDSConnection:
             pid=threading.get_native_id(),
         )
         self.conn.reconnect()
+        self.open_trees = []
 
     @_better_mds_exceptions
     def open_tree(self, tree_name: str):

--- a/disruption_py/inout/sql.py
+++ b/disruption_py/inout/sql.py
@@ -146,8 +146,9 @@ class ShotDatabase:
         current_thread = threading.current_thread()
         if current_thread not in self._thread_connections:
             logger.debug(
-                "Connecting to database for thread {current_thread}",
-                current_thread=str(current_thread),
+                "PID #{pid} | Connecting to SQL database: -> {server}",
+                pid=threading.get_native_id(),
+                server=self.host,
             )
             self._thread_connections[current_thread] = pyodbc.connect(
                 self.connection_string

--- a/disruption_py/inout/sql.py
+++ b/disruption_py/inout/sql.py
@@ -146,7 +146,7 @@ class ShotDatabase:
         current_thread = threading.current_thread()
         if current_thread not in self._thread_connections:
             logger.debug(
-                "PID #{pid} | Connecting to SQL database: -> {server}",
+                "PID #{pid} | Connecting to SQL database: {server}",
                 pid=threading.get_native_id(),
                 server=self.host,
             )


### PR DESCRIPTION
re-implement the good practice of closing the trees we opened after each shot.
if we catch an `MDSplusERROR`, it might mean that we encountered a severely-corrupted MDSplus tree.
in that case, the MDSplus connection itself might be compromised and would require a reconnection.
to mitigate this we purge any untrustworthy data related to our shot, but at least we will be able to retrieve healthy data for further shots processed by the same connection.

- catch any exception at setup
- reconnect if method fails
- catch any exception at cleanup
- close all trees at cleanup
- reconnect if cleanup failed
- better PID-specific logs for connections

tested with both a 1-proc and 2-proc job with a bad shot, followed by a good shot:
```
# C-MOD
poetry run disruption-py 1150528006 1150805012
# old -> [104 rows x 63 columns]
# new -> [187 rows x 63 columns]
```
```
# DIII-D
poetry run disruption-py 175316 161228
# old -> [165 rows x 59 columns]
# new -> [412 rows x 59 columns]
```
```
# EAST
poetry run disruption-py 72466 55555
# old ->  [92 rows x 79 columns]
# new -> [161 rows x 79 columns]
```
