### PR TITLE
Simplify syntax to get data from PTDATA 

### DIFF
--- a/disruption_py/inout/mds.py
+++ b/disruption_py/inout/mds.py
@@ -240,7 +240,7 @@ class MDSConnection:
 
         dim_nums = dim_nums or [0]
 
-        if tree_name == "ptdata":
+        if tree_name.lower() == "ptdata":
             path, tree_name = self._resolve_d3d_ptdata_path(path)
 
         if tree_name is not None:

--- a/disruption_py/inout/mds.py
+++ b/disruption_py/inout/mds.py
@@ -194,7 +194,7 @@ class MDSConnection:
         np.ndarray
             Returns the node data.
         """
-        if tree_name == "ptdata":
+        if tree_name and tree_name.lower() == "ptdata":
             path, tree_name = self._resolve_d3d_ptdata_path(path)
 
         if tree_name is not None:
@@ -240,7 +240,7 @@ class MDSConnection:
 
         dim_nums = dim_nums or [0]
 
-        if tree_name.lower() == "ptdata":
+        if tree_name and tree_name.lower() == "ptdata":
             path, tree_name = self._resolve_d3d_ptdata_path(path)
 
         if tree_name is not None:
@@ -289,7 +289,7 @@ class MDSConnection:
 
         dim_nums = dim_nums or [0]
 
-        if tree_name == "ptdata":
+        if tree_name and tree_name.lower() == "ptdata":
             path, tree_name = self._resolve_d3d_ptdata_path(path)
 
         if tree_name is not None:
@@ -329,11 +329,11 @@ class MDSConnection:
         """
         return self.get_tree_name_of_nickname(for_name) or for_name
 
-    def _resolve_d3d_ptdata_path(self, path: str) -> Tuple[str, str]:
+    def _resolve_d3d_ptdata_path(self, path: str) -> Tuple[str, None]:
         """
         This function allows a user to specify tree = 'ptdata' in get methods.
         It only works with simple expressions (i.e. no additional mathematical operations).
 
-        Return the ptdata path and tree='d3d'
+        Return the ptdata path and tree=None
         """
-        return [f'ptdata("{path}", {self.shot_id})', "d3d"]
+        return [f'ptdata("{path}", {self.shot_id})', None]

--- a/disruption_py/inout/mds.py
+++ b/disruption_py/inout/mds.py
@@ -194,6 +194,8 @@ class MDSConnection:
         np.ndarray
             Returns the node data.
         """
+        if tree_name == "ptdata":
+            path, tree_name = self._resolve_d3d_ptdata_path(path)
 
         if tree_name is not None:
             self.open_tree(tree_name)
@@ -237,6 +239,9 @@ class MDSConnection:
         """
 
         dim_nums = dim_nums or [0]
+
+        if tree_name == "ptdata":
+            path, tree_name = self._resolve_d3d_ptdata_path(path)
 
         if tree_name is not None:
             self.open_tree(tree_name)
@@ -284,6 +289,9 @@ class MDSConnection:
 
         dim_nums = dim_nums or [0]
 
+        if tree_name == "ptdata":
+            path, tree_name = self._resolve_d3d_ptdata_path(path)
+
         if tree_name is not None:
             self.open_tree(tree_name)
 
@@ -320,3 +328,12 @@ class MDSConnection:
         The tree name for for_name, whether it is a nickname or tree name itself
         """
         return self.get_tree_name_of_nickname(for_name) or for_name
+
+    def _resolve_d3d_ptdata_path(self, path: str) -> Tuple[str, str]:
+        """
+        This function allows a user to specify tree = 'ptdata' in get methods.
+        It only works with simple expressions (i.e. no additional mathematical operations).
+
+        Return the ptdata path and tree='d3d'
+        """
+        return [f'ptdata("{path}", {self.shot_id})', "d3d"]


### PR DESCRIPTION
This PR allows a user to use

 `conn.get_data('ip', tree_name='ptdata')`

to replace 

<s> `conn.get_data(f'ptdata("ip", {params.shot_id}, tree_name='d3d')` </s>
`conn.get_data(f'ptdata("ip", {params.shot_id}, tree_name=None)`


For the moment, this is only needed for using `SignalTimeSetting` with PTDATA signals on DIII-D. Therefore I did not modify any expression in `d3d/physics.py` or anywhere else. It also only works with simple expressions (i.e. it won't work with additional arithmetic operations).
