### PR TITLE
Remove previously added XFAILs due to east/east_1 tree issues

### DIFF
--- a/disruption_py/machine/east/config.toml
+++ b/disruption_py/machine/east/config.toml
@@ -20,9 +20,6 @@ expected_failure_columns = [
   "li_rt",
   "mirnov_std",
   "mirnov_std_normalized",
-  "n_equal_1_mode", # east/east_1 tree issues
-  "n_equal_1_normalized", # east/east_1 tree issues
-  "n_equal_1_phase", # east/east_1 tree issues
   "p_input",
   "p_lh", # east/east_1 tree issues
   "p_oh",
@@ -33,9 +30,6 @@ expected_failure_columns = [
   "qstar",
   "rad_input_frac",
   "rad_loss_frac",
-  "rmp_n_equal_1", # east/east_1 tree issues
-  "rmp_n_equal_1_phase", # east/east_1 tree issues
-  "v_loop", # east/east_1 tree issues
   "wmhd",
   "wmhd_rt",
 ]


### PR DESCRIPTION
# Implemented changes

- Removed 6 out of 8 signals that are previously affected by the `east`/`east_1` tree errors. All these signals get their raw data from the `east` tree.
- The remaining 2 signals (`p_lh` and `p_rad`) still show up as XFAIL instead of XPASS in the test. Both of them use data from the `east_1` tree. I need to take a closer look to see what's causing the problem.

# Related PRs
- #411 
- #451 