### PR TITLE
Remove shorten_path

### DIFF
--- a/disruption_py/inout/mds.py
+++ b/disruption_py/inout/mds.py
@@ -36,10 +36,6 @@ class ProcessMDSConnection:
         )
         # pylint: disable=no-member
         self.conn = MDSplus.Connection(conn_string)
-        try:
-            self.conn.get("shorten_path()")
-        except MDSplus.mdsExceptions.TdiUNKNOWN_VAR:
-            logger.debug("MDSplus does not support the `shorten_path()` method.")
 
     @classmethod
     def from_config(cls, tokamak: Tokamak):


### PR DESCRIPTION
`shorten_path` is not a native feature of MDSplus, but rather a very much ad-hoc TDI command for Alcator C-MOD servers.
environmental variables can and should be exploited to the same effect.