### PR TITLE
Suppress git errors for non-git execution

### DIFF
--- a/disruption_py/core/utils/misc.py
+++ b/disruption_py/core/utils/misc.py
@@ -47,7 +47,9 @@ def get_commit_hash() -> str:
     """
     try:
         commit_hash = (
-            subprocess.check_output(["git", "rev-parse", "HEAD"])
+            subprocess.check_output(
+                ["git", "rev-parse", "HEAD"], stderr=subprocess.DEVNULL
+            )
             .decode("ascii")
             .strip()
         )


### PR DESCRIPTION
suppress stderr when looking up commit, so that non-git execution does not show the usual error:

```
fatal: not a git repository (or any of the parent directories): .git
```