### PR TITLE
EQDSK methods

### DIFF
--- a/disruption_py/machine/cmod/efit.py
+++ b/disruption_py/machine/cmod/efit.py
@@ -5,6 +5,7 @@ Module for retrieving and processing EFIT parameters for CMOD.
 """
 
 import numpy as np
+import xarray as xr
 
 from disruption_py.core.physics_method.decorator import physics_method
 from disruption_py.core.physics_method.params import PhysicsMethodParams
@@ -98,6 +99,251 @@ class CmodEfitMethods:
                 efit_data[param] = interp1(efit_time, efit_data[param], params.times)
 
         return efit_data
+
+    @staticmethod
+    @physics_method(
+        tokamak=Tokamak.CMOD,
+    )
+    def get_geqdsk_parameters(params: PhysicsMethodParams):
+        """
+        Retrieve parameters required to create a GEQDSKFile https://freeqdsk.readthedocs.io/en/stable/geqdsk.html
+        Also see https://fusion.gat.com/theory/Efitgeqdsk
+        This requires the following:
+        
+        1. shot number
+        2. grid parameters: (nx, ny, rdim, zdim, rcenter, rleft, zmid) or (rgrid, zgrid)
+        3. scalar parameters: rmagx, zmagx, simagx, sibdry, bccenter, cpasma, etc.
+        4. 1D profile parameters: fpol, pres, ffprime, pprime, qpsi
+        5. 2D parameters: psi or f or psirz
+        6. boundary and limiter data (if available): nbdry, nlim, rbdry, zbdry, rlim, zlim
+
+        Sometimes the C-Mod EFIT uses 'x' and 'y' instead of 'r' and 'z' for parameter names
+        This function will convert them to the standard GEQDSK naming convention.
+
+        Also, it doesn't make sense to get interpolated boundary/limiter data because the number of points can change over time.
+        TODO(ZanderKeith): How should we handle this case?
+
+        Parameters
+        ----------
+        params : PhysicsMethodParams
+            Parameters containing MDS connection and shot information.
+        Returns
+        -------
+        xarray.Dataset
+            A dataset containing the GEQDSK parameters.
+        """
+        # Get EFIT time array
+        efit_time = params.mds_conn.get_data(r"\efit_a_eqdsk:atime", tree_name="_efit_tree")
+
+        # Grid parameters (For C-Mod a lot are missing, but can be inferred from rgrid/zgrid)
+        grid_params = {
+            "nw": params.mds_conn.get_data(r"\efit_g_eqdsk:mw", tree_name="_efit_tree"),        # Number of horizontal grid points
+            "nh": params.mds_conn.get_data(r"\efit_g_eqdsk:mh", tree_name="_efit_tree"),        # Number of vertical grid points
+            "rdim": params.mds_conn.get_data(r"\efit_g_eqdsk:xdim", tree_name="_efit_tree"),    # Horizontal dimension of grid [m]
+            "zdim": params.mds_conn.get_data(r"\efit_g_eqdsk:zdim", tree_name="_efit_tree"),    # Vertical dimension of grid [m]
+        }
+        rgrid = params.mds_conn.get_data(r"\efit_g_eqdsk:rgrid", tree_name="_efit_tree")  # R grid [m]
+        zgrid = params.mds_conn.get_data(r"\efit_g_eqdsk:zgrid", tree_name="_efit_tree")  # Z grid [m]
+
+        # Scalar parameters
+        scalar_params = {
+            # Plasma parameters
+            "cpasma": params.mds_conn.get_data(r"\efit_g_eqdsk:cpasma", tree_name="_efit_tree"),  # Plasma current [A]
+            "bcentr": params.mds_conn.get_data(r"\efit_g_eqdsk:bcentr", tree_name="_efit_tree"),  # Vacuum toroidal field [T]
+
+            # Magnetic axis
+            # Note that ssimag is -1 * simagx from the aeqdsk, apparently
+            "rmaxis": params.mds_conn.get_data(r"\efit_g_eqdsk:rmaxis", tree_name="_efit_tree"), # R of magnetic axis [m]
+            "zmaxis": params.mds_conn.get_data(r"\efit_g_eqdsk:zmaxis", tree_name="_efit_tree"), # Z of magnetic axis [m]
+            "ssimag": params.mds_conn.get_data(r"\efit_g_eqdsk:ssimag", tree_name="_efit_tree"), # Flux at magnetic axis [Wb]
+
+            # Plasma boundary
+            "ssibry": params.mds_conn.get_data(r"\efit_g_eqdsk:ssibry", tree_name="_efit_tree"),   # Flux at plasma boundary [Wb]
+        }
+
+        # 1D profile parameters
+        profile_params = {
+            "fpol": params.mds_conn.get_data(r"\efit_g_eqdsk:fpol", tree_name="_efit_tree"),     # F = R*Bt [T*m]
+            "pres": params.mds_conn.get_data(r"\efit_g_eqdsk:pres", tree_name="_efit_tree"),     # Pressure [Pa]
+            "ffprim": params.mds_conn.get_data(r"\efit_g_eqdsk:ffprim", tree_name="_efit_tree"), # F*dF/dpsi
+            "pprime": params.mds_conn.get_data(r"\efit_g_eqdsk:pprime", tree_name="_efit_tree"), # dp/dpsi
+            "qpsi": params.mds_conn.get_data(r"\efit_g_eqdsk:qpsi", tree_name="_efit_tree"),     # Safety factor q
+        }
+
+        # 2D flux map
+        psi_2d = params.mds_conn.get_data(r"\efit_g_eqdsk:psirz", tree_name="_efit_tree")  # 2D flux map [Wb]
+
+        # Boundary and limiter data
+        try:
+            rbbbs = params.mds_conn.get_data(r"\efit_g_eqdsk:rbbbs", tree_name="_efit_tree")  # R of boundary points [m]
+            zbbbs = params.mds_conn.get_data(r"\efit_g_eqdsk:zbbbs", tree_name="_efit_tree")  # Z of boundary points [m]
+            nbbbs = params.mds_conn.get_data(r"\efit_g_eqdsk:nbbbs", tree_name="_efit_tree")  # Number of boundary points
+        except:
+            # Set empty boundary if not available
+            rbbbs = np.array([])
+            zbbbs = np.array([])
+            nbbbs = 0
+
+        # For some reason there is a difference in shape between xlim,ylim, and lim
+        try:
+            xlim = params.mds_conn.get_data(r"\efit_g_eqdsk:xlim", tree_name="_efit_tree")   # R of limiter points [m]
+            ylim = params.mds_conn.get_data(r"\efit_g_eqdsk:ylim", tree_name="_efit_tree")   # Z of limiter points [m]
+        except:
+            # Set empty limiter if not available
+            xlim = np.array([])
+            ylim = np.array([])
+        nlim = xlim.shape[0] if xlim.ndim > 0 else 0   # Number of limiter points
+
+        # Create data variables for the dataset
+        data_vars = {}
+
+        # Add scalar parameters
+        for param, values_raw in scalar_params.items():
+            values_interp = interp1(efit_time, values_raw, params.times)
+            data_vars[param] = xr.DataArray(
+                values_interp,
+                dims=["idx"],
+                coords={"time": ("idx", params.times)},
+                attrs={"description": f"GEQDSK parameter {param}"}
+            )
+
+        # Add 1D profile parameters.
+        for param, values_raw in profile_params.items():
+            if values_raw.ndim == 2:  # Time-dependent profiles
+                # For some reason these are stored as (psi_idx, time) so transpose them
+                values_interp = np.array([interp1(efit_time, values_raw[i, :], params.times) for i in range(values_raw.shape[0])]).T
+                data_vars[param] = xr.DataArray(
+                    values_interp,
+                    dims=["idx", "psi_idx"],
+                    coords={
+                        "time": ("idx", params.times),
+                        "psi_idx": np.arange(values_interp.shape[1])
+                    },
+                    attrs={"description": f"GEQDSK 1D profile {param}"}
+                )
+            else:  # Single profile
+                data_vars[param] = xr.DataArray(
+                    values_raw,
+                    dims=["psi_idx"],
+                    coords={"psi_idx": np.arange(len(values_raw))},
+                    attrs={"description": f"GEQDSK 1D profile {param}"}
+                )
+
+        # Add 2D flux map
+        if psi_2d.ndim == 3:  # Time-dependent 2D data
+            psi_2d_interp = np.array([[interp1(efit_time, psi_2d[:, i, j], params.times) for j in range(psi_2d.shape[2])] for i in range(psi_2d.shape[1])]).T
+            data_vars["psirz"] = xr.DataArray(
+                psi_2d_interp,
+                dims=["idx", "r_idx", "z_idx"],
+                coords={
+                    "time": ("idx", params.times),
+                    "r_idx": ("r_idx", np.arange(psi_2d.shape[1])),
+                    "z_idx": ("z_idx", np.arange(psi_2d.shape[2])),
+                    "rgrid": ("r_idx", rgrid[0]),
+                    "zgrid": ("z_idx", zgrid[0])
+                },
+                attrs={"description": "2D poloidal flux map", "units": "Wb"}
+            )
+        else:  # Single time slice
+            data_vars["psirz"] = xr.DataArray(
+                psi_2d,
+                dims=["r_idx", "z_idx"],
+                coords={
+                    "r_idx": np.arange(psi_2d.shape[1]),
+                    "z_idx": np.arange(psi_2d.shape[2]),
+                    "rgrid": ("r_idx", rgrid[0]),
+                    "zgrid": ("z_idx", zgrid[0])
+                },
+                attrs={"description": "2D poloidal flux map", "units": "Wb"}
+            )
+
+        # Add boundary data
+        if len(rbbbs) > 0:
+            if rbbbs.ndim == 2:  # Time-dependent boundary
+                # Transpose to (time, boundary_idx)
+                rbbbs_interp = np.array([interp1(efit_time, rbbbs[i, :], params.times) for i in range(rbbbs.shape[0])]).T
+                data_vars["rbbbs"] = xr.DataArray(
+                    rbbbs_interp,
+                    dims=["idx", "boundary_idx"],
+                    coords={
+                        "time": ("idx", params.times),
+                        "boundary_idx": np.arange(rbbbs_interp.shape[1])
+                    },
+                    attrs={"description": "R coordinates of plasma boundary", "units": "m"}
+                )
+                zbbbs_interp = np.array([interp1(efit_time, zbbbs[i, :], params.times) for i in range(zbbbs.shape[0])]).T
+                data_vars["zbbbs"] = xr.DataArray(
+                    zbbbs_interp,
+                    dims=["idx", "boundary_idx"],
+                    coords={
+                        "time": ("idx", params.times),
+                        "boundary_idx": np.arange(zbbbs_interp.shape[1])
+                    },
+                    attrs={"description": "Z coordinates of plasma boundary", "units": "m"}
+                )
+                nbbbs_interp = interp1(efit_time, nbbbs, params.times)
+                data_vars["nbbbs"] = xr.DataArray(
+                    nbbbs_interp,
+                    dims=["idx"],
+                    coords={"time": ("idx", params.times)},
+                    attrs={"description": "Number of boundary points"}
+                )
+            else:  # Single boundary
+                data_vars["rbbbs"] = xr.DataArray(
+                    rbbbs,
+                    dims=["boundary_idx"],
+                    coords={"boundary_idx": np.arange(len(rbbbs))},
+                    attrs={"description": "R coordinates of plasma boundary", "units": "m"}
+                )
+                data_vars["zbbbs"] = xr.DataArray(
+                    zbbbs,
+                    dims=["boundary_idx"],
+                    coords={"boundary_idx": np.arange(len(zbbbs))},
+                    attrs={"description": "Z coordinates of plasma boundary", "units": "m"}
+                )
+                data_vars["nbbbs"] = xr.DataArray(
+                    nbbbs,
+                    dims=[],
+                    attrs={"description": "Number of boundary points"}
+                )
+
+        # Add limiter data and change the name to match GEQDSK convention
+        if len(xlim) > 0:
+            data_vars["rlim"] = xr.DataArray(
+                xlim,
+                dims=["limiter_idx"],
+                coords={"limiter_idx": np.arange(len(xlim))},
+                attrs={"description": "R coordinates of limiter", "units": "m"}
+            )
+            data_vars["zlim"] = xr.DataArray(
+                ylim,
+                dims=["limiter_idx"],
+                coords={"limiter_idx": np.arange(len(ylim))},
+                attrs={"description": "Z coordinates of limiter", "units": "m"}
+            )
+        data_vars["nlim"] = xr.DataArray(
+            nlim,
+            dims=[],
+            attrs={"description": "Number of limiter points"}
+        )
+
+        data_vars.update(grid_params)
+
+        # Create the dataset
+        geqdsk_dataset = xr.Dataset(
+            data_vars=data_vars,
+            coords={
+                "time": ("idx", params.times),
+                "shot": ("idx", np.repeat(params.shot_id, len(params.times), axis=0)),
+            },
+            attrs={
+                "description": "GEQDSK equilibrium parameters for C-Mod",
+                "source": "EFIT reconstruction",
+            }
+        )
+
+        return geqdsk_dataset
+
 
     @staticmethod
     def efit_check(params: PhysicsMethodParams):

--- a/disruption_py/machine/cmod/efit.py
+++ b/disruption_py/machine/cmod/efit.py
@@ -239,8 +239,8 @@ class CmodEfitMethods:
                     "time": ("idx", params.times),
                     "r_idx": ("r_idx", np.arange(psi_2d.shape[1])),
                     "z_idx": ("z_idx", np.arange(psi_2d.shape[2])),
-                    "rgrid": ("r_idx", rgrid[0]),
-                    "zgrid": ("z_idx", zgrid[0])
+                    "rgrid": ("r_idx", rgrid),
+                    "zgrid": ("z_idx", zgrid)
                 },
                 attrs={"description": "2D poloidal flux map", "units": "Wb"}
             )
@@ -251,8 +251,8 @@ class CmodEfitMethods:
                 coords={
                     "r_idx": np.arange(psi_2d.shape[1]),
                     "z_idx": np.arange(psi_2d.shape[2]),
-                    "rgrid": ("r_idx", rgrid[0]),
-                    "zgrid": ("z_idx", zgrid[0])
+                    "rgrid": ("r_idx", rgrid),
+                    "zgrid": ("z_idx", zgrid)
                 },
                 attrs={"description": "2D poloidal flux map", "units": "Wb"}
             )

--- a/disruption_py/machine/d3d/config.toml
+++ b/disruption_py/machine/d3d/config.toml
@@ -1,5 +1,5 @@
 [d3d.efit]
-runtag = "DIS"
+runtag = "DISPY"
 
 [d3d.inout.mds]
 mdsplus_connection_string = "atlas"

--- a/disruption_py/machine/d3d/efit.py
+++ b/disruption_py/machine/d3d/efit.py
@@ -5,6 +5,7 @@ Module for retrieving and processing EFIT parameters for DIII-D.
 """
 
 import numpy as np
+import xarray as xr
 
 from disruption_py.core.physics_method.decorator import physics_method
 from disruption_py.core.physics_method.params import PhysicsMethodParams
@@ -128,3 +129,253 @@ class D3DEfitMethods:
             for param in efit_data:
                 efit_data[param] = interp1(efit_time, efit_data[param], params.times)
         return efit_data
+
+    @staticmethod
+    @physics_method(
+        tokamak=Tokamak.D3D,
+    )
+    def get_geqdsk_parameters(params: PhysicsMethodParams):
+        """
+        Retrieve parameters required to create a GEQDSKFile https://freeqdsk.readthedocs.io/en/stable/geqdsk.html
+        Also see https://fusion.gat.com/theory/Efitgeqdsk
+        This requires the following:
+        
+        1. shot number
+        2. grid parameters: (nx, ny, rdim, zdim, rcenter, rleft, zmid) or (rgrid, zgrid)
+        3. scalar parameters: rmagx, zmagx, simagx, sibdry, bccenter, cpasma, etc.
+        4. 1D profile parameters: fpol, pres, ffprime, pprime, qpsi
+        5. 2D parameters: psi or f or psirz
+        6. boundary and limiter data (if available): nbdry, nlim, rbdry, zbdry, rlim, zlim
+
+        Some signals are missing on DIII-D but can be inferred from other signals, when this happens it is noted below.
+
+        Also, it doesn't make sense to get interpolated limiter data ('nbbbs', 'rbbbs', 'zbbbs') because the number of points can change over time.
+        TODO(ZanderKeith): How should we handle this case?
+        
+        Parameters
+        ----------
+        params : PhysicsMethodParams
+            Parameters containing MDS connection and shot information.
+
+        Returns
+        -------
+        xarray.Dataset
+            A dataset containing the GEQDSK parameters.
+
+        """
+        # Get EFIT time array
+        efit_time = params.mds_conn.get_data(
+            r"\efit_a_eqdsk:atime", tree_name="_efit_tree"
+        ) / 1.0e3  # [ms] -> [s]
+
+        # Grid parameters
+        # For DIII-D, rcentr and rleft are missing but can be inferred from rgrid
+        grid_params = {
+            "nw": params.mds_conn.get_data(r"\efit_g_eqdsk:mw", tree_name="_efit_tree"),        # Number of horizontal grid points
+            "nh": params.mds_conn.get_data(r"\efit_g_eqdsk:mh", tree_name="_efit_tree"),        # Number of vertical grid points
+            "rdim": params.mds_conn.get_data(r"\efit_g_eqdsk:xdim", tree_name="_efit_tree"),    # Horizontal dimension of grid [m]
+            "zdim": params.mds_conn.get_data(r"\efit_g_eqdsk:zdim", tree_name="_efit_tree"),    # Vertical dimension of grid [m]
+            "zmid": params.mds_conn.get_data(r"\efit_g_eqdsk:zmid", tree_name="_efit_tree"),    # Z at center of grid [m]
+        }
+        rgrid = params.mds_conn.get_data(r"\efit_g_eqdsk:r", tree_name="_efit_tree"),  # R grid [m]
+        zgrid = params.mds_conn.get_data(r"\efit_g_eqdsk:z", tree_name="_efit_tree"),  # Z grid [m]
+
+        # Scalar parameters
+        scalar_params = {
+            # Plasma parameters
+            "cpasma": params.mds_conn.get_data(r"\efit_g_eqdsk:cpasma", tree_name="_efit_tree"),  # Plasma current [A]
+            "bcentr": params.mds_conn.get_data(r"\efit_g_eqdsk:bcentr", tree_name="_efit_tree"),  # Vacuum toroidal field [T]
+
+            # Magnetic axis
+            "rmaxis": params.mds_conn.get_data(r"\efit_g_eqdsk:rmaxis", tree_name="_efit_tree"), # R of magnetic axis [m]
+            "zmaxis": params.mds_conn.get_data(r"\efit_g_eqdsk:zmaxis", tree_name="_efit_tree"), # Z of magnetic axis [m]
+            "simag": params.mds_conn.get_data(r"\efit_g_eqdsk:ssimag", tree_name="_efit_tree"),  # Flux at magnetic axis [Wb]
+
+            # Plasma boundary
+            "sibry": params.mds_conn.get_data(r"\efit_g_eqdsk:ssibry", tree_name="_efit_tree"),  # Flux at plasma boundary [Wb]
+            "xdim": params.mds_conn.get_data(r"\efit_g_eqdsk:xdim", tree_name="_efit_tree"),     # X-point R location [m]
+            "zdim": params.mds_conn.get_data(r"\efit_g_eqdsk:zdim", tree_name="_efit_tree"),     # X-point Z location [m]
+        }
+
+        # 1D profile parameters
+        profile_params = {
+            "fpol": params.mds_conn.get_data(r"\efit_g_eqdsk:fpol", tree_name="_efit_tree"),     # F = R*Bt [T*m]
+            "pres": params.mds_conn.get_data(r"\efit_g_eqdsk:pres", tree_name="_efit_tree"),     # Pressure [Pa]
+            "ffprim": params.mds_conn.get_data(r"\efit_g_eqdsk:ffprim", tree_name="_efit_tree"), # F*dF/dpsi
+            "pprime": params.mds_conn.get_data(r"\efit_g_eqdsk:pprime", tree_name="_efit_tree"), # dp/dpsi
+            "qpsi": params.mds_conn.get_data(r"\efit_g_eqdsk:qpsi", tree_name="_efit_tree"),     # Safety factor q
+        }
+
+        # 2D flux map
+        psi_2d = params.mds_conn.get_data(r"\efit_g_eqdsk:psirz", tree_name="_efit_tree")  # 2D flux map [Wb]
+
+        # Boundary and limiter data
+        try:
+            rbbbs = params.mds_conn.get_data(r"\efit_g_eqdsk:rbbbs", tree_name="_efit_tree")  # R of boundary points [m]
+            zbbbs = params.mds_conn.get_data(r"\efit_g_eqdsk:zbbbs", tree_name="_efit_tree")  # Z of boundary points [m]
+            nbbbs = params.mds_conn.get_data(r"\efit_g_eqdsk:nbbbs", tree_name="_efit_tree")  # Number of boundary points
+        except:
+            # Set empty boundary if not available
+            rbbbs = np.array([])
+            zbbbs = np.array([])
+            nbbbs = 0
+
+        try:
+            rlim = params.mds_conn.get_data(r"\efit_g_eqdsk:xlim", tree_name="_efit_tree")   # R of limiter points [m]
+            zlim = params.mds_conn.get_data(r"\efit_g_eqdsk:ylim", tree_name="_efit_tree")   # Z of limiter points [m]
+            nlim = params.mds_conn.get_data(r"\efit_g_eqdsk:nlim", tree_name="_efit_tree")   # Number of limiter points
+        except:
+            # Set empty limiter if not available
+            rlim = np.array([])
+            zlim = np.array([])
+            nlim = 0
+
+        # Create time-dependent data arrays
+        data_vars = {}
+
+        # Add scalar parameters
+        for param, values_raw in scalar_params.items():
+            values_interp = interp1(efit_time, values_raw, params.times)
+            data_vars[param] = xr.DataArray(
+                values_interp,
+                dims=["idx"],
+                coords={"time": ("idx", params.times)},
+                attrs={"description": f"GEQDSK parameter {param}"}
+            )
+
+        # Add 1D profile parameters.
+        for param, values_raw in profile_params.items():
+            if values_raw.ndim == 2:  # Time-dependent profiles
+                # These are stored as (time, psi_idx)
+                values_interp = np.array([interp1(efit_time, values_raw[:, i], params.times) for i in range(values_raw.shape[1])]).T
+                data_vars[param] = xr.DataArray(
+                    values_interp,
+                    dims=["idx", "psi_idx"],
+                    coords={
+                        "time": ("idx", params.times),
+                        "psi_idx": np.arange(values_interp.shape[1])
+                    },
+                    attrs={"description": f"GEQDSK 1D profile {param}"}
+                )
+            else:  # Single profile
+                data_vars[param] = xr.DataArray(
+                    values_raw,
+                    dims=["psi_idx"],
+                    coords={"psi_idx": np.arange(len(values_raw))},
+                    attrs={"description": f"GEQDSK 1D profile {param}"}
+                )
+
+        # Add 2D flux map
+        if psi_2d.ndim == 3:  # Time-dependent 2D data
+            psi_2d_interp = np.array([[interp1(efit_time, psi_2d[:, i, j], params.times) for j in range(psi_2d.shape[2])] for i in range(psi_2d.shape[1])]).T
+            data_vars["psirz"] = xr.DataArray(
+                psi_2d_interp,
+                dims=["idx", "r_idx", "z_idx"],
+                coords={
+                    "time": ("idx", params.times),
+                    "r_idx": ("r_idx", np.arange(psi_2d.shape[1])),
+                    "z_idx": ("z_idx", np.arange(psi_2d.shape[2])),
+                    "rgrid": ("r_idx", rgrid[0]),
+                    "zgrid": ("z_idx", zgrid[0])
+                },
+                attrs={"description": "2D poloidal flux map", "units": "Wb"}
+            )
+        else:  # Single time slice
+            data_vars["psirz"] = xr.DataArray(
+                psi_2d,
+                dims=["r_idx", "z_idx"],
+                coords={
+                    "r_idx": np.arange(psi_2d.shape[1]),
+                    "z_idx": np.arange(psi_2d.shape[2]),
+                    "rgrid": ("r_idx", rgrid[0]),
+                    "zgrid": ("z_idx", zgrid[0])
+                },
+                attrs={"description": "2D poloidal flux map", "units": "Wb"}
+            )
+
+        # Add boundary data
+        if len(rbbbs) > 0:
+            if rbbbs.ndim == 2:  # Time-dependent boundary
+                # These are stored as (time, boundary_idx)
+                rbbbs_interp = np.array([interp1(efit_time, rbbbs[:, i], params.times) for i in range(rbbbs.shape[1])]).T
+                data_vars["rbbbs"] = xr.DataArray(
+                    rbbbs_interp,
+                    dims=["idx", "boundary_idx"],
+                    coords={
+                        "time": ("idx", params.times),
+                        "boundary_idx": np.arange(rbbbs_interp.shape[1])
+                    },
+                    attrs={"description": "R coordinates of plasma boundary", "units": "m"}
+                )
+                zbbbs_interp = np.array([interp1(efit_time, zbbbs[:, i], params.times) for i in range(zbbbs.shape[1])]).T
+                data_vars["zbbbs"] = xr.DataArray(
+                    zbbbs_interp,
+                    dims=["idx", "boundary_idx"],
+                    coords={
+                        "time": ("idx", params.times),
+                        "boundary_idx": np.arange(zbbbs_interp.shape[1])
+                    },
+                    attrs={"description": "Z coordinates of plasma boundary", "units": "m"}
+                ),
+                nbbbs_interp = np.array([interp1(efit_time, nbbbs, params.times)])
+                data_vars["nbbbs"] = xr.DataArray(
+                    nbbbs_interp,
+                    dims=["idx"],
+                    coords={"time": ("idx", params.times)},
+                    attrs={"description": "Number of boundary points"}
+                )
+            else:  # Single boundary
+                data_vars["rbbbs"] = xr.DataArray(
+                    rbbbs,
+                    dims=["boundary_idx"],
+                    coords={"boundary_idx": np.arange(len(rbbbs))},
+                    attrs={"description": "R coordinates of plasma boundary", "units": "m"}
+                )
+                data_vars["zbbbs"] = xr.DataArray(
+                    zbbbs,
+                    dims=["boundary_idx"],
+                    coords={"boundary_idx": np.arange(len(zbbbs))},
+                    attrs={"description": "Z coordinates of plasma boundary", "units": "m"}
+                )
+                data_vars["nbbbs"] = xr.DataArray(
+                    nbbbs,
+                    dims=[],
+                    attrs={"description": "Number of boundary points"}
+                )
+
+        # Add limiter data and change the name to match GEQDSK convention
+        if len(rlim) > 0:
+            data_vars["rlim"] = xr.DataArray(
+                rlim,
+                dims=["limiter_idx"],
+                coords={"limiter_idx": np.arange(len(rlim))},
+                attrs={"description": "R coordinates of limiter", "units": "m"}
+            )
+            data_vars["zlim"] = xr.DataArray(
+                zlim,
+                dims=["limiter_idx"],
+                coords={"limiter_idx": np.arange(len(zlim))},
+                attrs={"description": "Z coordinates of limiter", "units": "m"}
+            )
+        data_vars["nlim"] = xr.DataArray(
+            nlim,
+            dims=[],
+            attrs={"description": "Number of limiter points"}
+        )
+
+        data_vars.update(grid_params)
+
+        # Create the dataset
+        geqdsk_dataset = xr.Dataset(
+            data_vars=data_vars,
+            coords={
+                "time": ("idx", params.times),
+                "shot": ("idx", np.repeat(params.shot_id, len(params.times), axis=0)),
+            },
+            attrs={
+                "description": "GEQDSK equilibrium parameters for DIII-D",
+                "source": "EFIT reconstruction",
+            }
+        )
+
+        return geqdsk_dataset

--- a/disruption_py/machine/d3d/efit.py
+++ b/disruption_py/machine/d3d/efit.py
@@ -177,8 +177,8 @@ class D3DEfitMethods:
             "zdim": params.mds_conn.get_data(r"\efit_g_eqdsk:zdim", tree_name="_efit_tree"),    # Vertical dimension of grid [m]
             "zmid": params.mds_conn.get_data(r"\efit_g_eqdsk:zmid", tree_name="_efit_tree"),    # Z at center of grid [m]
         }
-        rgrid = params.mds_conn.get_data(r"\efit_g_eqdsk:r", tree_name="_efit_tree"),  # R grid [m]
-        zgrid = params.mds_conn.get_data(r"\efit_g_eqdsk:z", tree_name="_efit_tree"),  # Z grid [m]
+        rgrid = params.mds_conn.get_data(r"\efit_g_eqdsk:r", tree_name="_efit_tree")  # R grid [m]
+        zgrid = params.mds_conn.get_data(r"\efit_g_eqdsk:z", tree_name="_efit_tree")  # Z grid [m]
 
         # Scalar parameters
         scalar_params = {
@@ -275,8 +275,8 @@ class D3DEfitMethods:
                     "time": ("idx", params.times),
                     "r_idx": ("r_idx", np.arange(psi_2d.shape[1])),
                     "z_idx": ("z_idx", np.arange(psi_2d.shape[2])),
-                    "rgrid": ("r_idx", rgrid[0]),
-                    "zgrid": ("z_idx", zgrid[0])
+                    "rgrid": ("r_idx", rgrid),
+                    "zgrid": ("z_idx", zgrid)
                 },
                 attrs={"description": "2D poloidal flux map", "units": "Wb"}
             )
@@ -287,8 +287,8 @@ class D3DEfitMethods:
                 coords={
                     "r_idx": np.arange(psi_2d.shape[1]),
                     "z_idx": np.arange(psi_2d.shape[2]),
-                    "rgrid": ("r_idx", rgrid[0]),
-                    "zgrid": ("z_idx", zgrid[0])
+                    "rgrid": ("r_idx", rgrid),
+                    "zgrid": ("z_idx", zgrid)
                 },
                 attrs={"description": "2D poloidal flux map", "units": "Wb"}
             )
@@ -316,8 +316,8 @@ class D3DEfitMethods:
                         "boundary_idx": np.arange(zbbbs_interp.shape[1])
                     },
                     attrs={"description": "Z coordinates of plasma boundary", "units": "m"}
-                ),
-                nbbbs_interp = np.array([interp1(efit_time, nbbbs, params.times)])
+                )
+                nbbbs_interp = interp1(efit_time, nbbbs, params.times)
                 data_vars["nbbbs"] = xr.DataArray(
                     nbbbs_interp,
                     dims=["idx"],

--- a/disruption_py/settings/time_setting.py
+++ b/disruption_py/settings/time_setting.py
@@ -700,6 +700,34 @@ class SharedTimeSetting(TimeSetting):
         tmax = np.min([np.max(t) for t in others])
         return times[np.where((times >= tmin) & (times <= tmax))]
 
+class Uniform1kHzTimeSetting(TimeSetting):
+    """
+    Time setting for creating a uniform timebase at 1 kHz, based on the maximum EFIT time.
+    """
+    def _get_times(self, params: TimeSettingParams) -> np.ndarray:
+        """
+        Parameters
+        ----------
+        params : TimeSettingParams
+            Parameters needed to retrieve the timebase.
+
+        Returns
+        -------
+        np.ndarray
+            Array of times in the timebase.
+        """
+        (efit_time,) = params.mds_conn.get_dims(
+            r"\efit_aeqdsk:ali", tree_name="_efit_tree"
+        )
+
+        max_time = np.max(efit_time)
+        if params.tokamak == Tokamak.CMOD:
+            times= np.round(np.arange(0, max_time + 1e-3, 1e-3), 3)
+            efit_time_unit = "s"
+        if params.tokamak == Tokamak.D3D:
+            times = np.round(np.arange(0, max_time + 1, 1), 0)
+            efit_time_unit = "ms"
+        return _postprocess(times=times, units=efit_time_unit)
 
 # --8<-- [start:time_setting_dict]
 _time_setting_mappings: Dict[str, TimeSetting] = {
@@ -712,6 +740,7 @@ _time_setting_mappings: Dict[str, TimeSetting] = {
     },
     "ip": IpTimeSetting(),
     "ip_efit": SharedTimeSetting([IpTimeSetting(), EfitTimeSetting()]),
+    "uniform_1kHz": Uniform1kHzTimeSetting(),
 }
 # --8<-- [end:time_setting_dict]
 


### PR DESCRIPTION
This PR adds additional methods for retrieving EFIT parameters to reconstruct a [GEQDSKFile](https://freeqdsk.readthedocs.io/en/stable/geqdsk.html#freeqdsk.geqdsk.GEQDSKFile) from the [FreeQDSK](https://freeqdsk.readthedocs.io/en/stable/index.html) library.

It also adds a new timebase option `uniform_1kHz` which is what I have been using for my POPSIM work across C-Mod, DIII-D, and TCV.

The one concern I have is regarding interpolation. If the requested timebase does not line up with EFIT, the data vars for limiter/boundary points stop meaning anything because the number of points can change between timesteps. This is an edge case I haven't given much thought to since I don't use these vars in any of my workflows, but it should probably be handled gracefully. Open to suggestions on how to address this.