### PR TITLE
Suppress warning for dummy DBs

### DIFF
--- a/disruption_py/inout/sql.py
+++ b/disruption_py/inout/sql.py
@@ -94,7 +94,7 @@ class ShotDatabase:
 
         # dummy database
         if not db_conf.get("host") or not db_conf.get("db_name"):
-            logger.warning("No SQL server/database!")
+            logger.debug("Did not setup database.")
             return DummyDatabase()
 
         # read sybase login


### PR DESCRIPTION
mention:
- #497

@samueljackson92 this would override some of your tweaks in a more robust way, that is, if no server is specified, then instantiate a Dummy DB without complaining.
all this will be revamped once more by Sameer anyways.