### PR TITLE
Fix FutureWarning when merging xarrays

### DIFF
--- a/disruption_py/core/physics_method/runner.py
+++ b/disruption_py/core/physics_method/runner.py
@@ -281,7 +281,7 @@ def populate_shot(
         datasets += [result]
 
     # merge dataarrays/datasets into dataset
-    dataset = xr.merge(datasets)
+    dataset = xr.merge(datasets, compat="no_conflicts")
 
     # log statistics
     if dataset:


### PR DESCRIPTION
default behavior of `xr.merge` will change (ref: pydata/xarray PR 10062), so let's silence the warning with an explicit `compat` assignment.