### PR TITLE
Fix extension check for IncludedShotlistSetting

### DIFF
--- a/disruption_py/settings/shotlist_setting.py
+++ b/disruption_py/settings/shotlist_setting.py
@@ -5,6 +5,7 @@ Handles retrieving shotlists from various sources including lists, files, and SQ
 databases.
 """
 
+import os
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from importlib import resources
@@ -98,7 +99,7 @@ class FileShotlistSetting(ShotlistSetting):
 
     def _get_shotlist(self, params: ShotlistSettingParams) -> List:
         if not self.shotlist:
-            if str(self.file_path).endswith(".parquet"):
+            if os.fspath(self.file_path).endswith(".parquet"):
                 df = pd.read_parquet(self.file_path, **self.kwargs)
             else:
                 self.kwargs.setdefault("header", "infer")


### PR DESCRIPTION
`IncludedShotlistSetting` might return a `PosixPath`, not a `str`.

```
$ uv run disruption-py cmod_ufo

[snip]
     if self.file_path.endswith(".parquet"):
       ^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'PosixPath' object has no attribute 'endswith'
```