### PR TITLE
Fix erroneous sorting of validity ranges

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,6 +113,7 @@ ignore_case = true
 in_place = true
 sort_table_keys = true
 trailing_comma_inline_array = true
+overrides."*.physics.attributes.*.validity".inline_arrays = false
 
 [tool.uv]
 default-groups = []


### PR DESCRIPTION
without this override, `toml-sort` would have sorted one C-MOD validity range, and rendered it unphysical:

https://github.com/MIT-PSFC/disruption-py/blob/c0c9242183a09f124fb94e14f904552a38265781/disruption_py/machine/cmod/config.toml#L293