### PR TITLE
Fix linting makefile

### DIFF
--- a/makefile
+++ b/makefile
@@ -127,6 +127,7 @@ shellcheck:
 	while IFS= read -r -d '' F; \
 	do \
 	   grep -q '^#!/bin/bash' "$$F" || continue; \
+	   echo "--> $$F"; \
 	   shellcheck "$$F"; \
 	   RC=$$?; \
 	   echo "--> $$F = $$RC"; \


### PR DESCRIPTION
return codes were previously mishandled for some looped workflows:
- `shellcheck`
- `toml-sort`
- `yamllint`

now:
- use loops with process substitution, rather than pipes,
- track and log single return codes,
- propagate final return code.

NDR: there might be a better way, but -- oh, well. :rabbit: 