### PR TITLE
Make bibliography formatting consistent for JOSS paper.

### DIFF
--- a/paper.bib
+++ b/paper.bib
@@ -9,11 +9,11 @@
   number	= {6},
   journal	= {Nuclear Fusion},
   publisher	= {IOP Publishing},
-  author	= {Hu, W.H. and Rea, C. and Yuan, Q.P. and Erickson, K.G. and
-		  Chen, D.L. and Shen, B. and Huang, Y. and Xiao, J.Y. and
-		  Chen, J.J. and Duan, Y.M. and Zhang, Y. and Zhuang, H.D.
-		  and Xu, J.C. and Montes, K.J. and Granetz, R.S. and Zeng,
-		  L. and Qian, J.P. and Xiao, B.J. and Li, J.G.},
+  author	= {Hu, W. H. and Rea, Cristina and Yuan, Q. P. and Erickson, K. G. and
+      Chen, D. L. and Shen, B. and Huang, Y. and Xiao, J. Y. and
+      Chen, J. J. and Duan, Y. M. and Zhang, Y. and Zhuang, H. D.
+      and Xu, J. C. and Montes, K. J. and Granetz, R. S. and Zeng,
+      L. and Qian, J. P. and Xiao, B. J. and Li, J. G.},
   year		= {2021},
   month		= may,
   pages		= {066034}
@@ -98,8 +98,8 @@
   number	= {1},
   journal	= {Nuclear Fusion},
   publisher	= {IOP Publishing},
-  author	= {Maris, A.D. and Rea, C. and Pau, A. and Hu, W. and Xiao,
-		  B. and Granetz, R. and Marmar, E.},
+  author	= {Maris, A. D. and Rea, Cristina and Pau, A. and Hu, W. and Xiao,
+      B. and Granetz, R. and Marmar, E.},
   year		= {2024},
   month		= dec,
   pages		= {016051}
@@ -115,10 +115,10 @@
   number	= {9},
   journal	= {Nuclear Fusion},
   publisher	= {IOP Publishing},
-  author	= {Montes, K.J. and Rea, C. and Granetz, R.S. and Tinguely,
-		  R.A. and Eidietis, N. and Meneghini, O.M. and Chen, D.L.
-		  and Shen, B. and Xiao, B.J. and Erickson, K. and Boyer,
-		  M.D.},
+  author	= {Montes, K. J. and Rea, Cristina and Granetz, R. S. and Tinguely,
+      R. A. and Eidietis, N. and Meneghini, O. M. and Chen, D. L.
+      and Shen, B. and Xiao, B. J. and Erickson, K. and Boyer,
+      M. D.},
   year		= {2019},
   month		= jul,
   pages		= {096015}
@@ -176,7 +176,7 @@
   number	= {1–2},
   journal	= {Fusion Science and Technology},
   publisher	= {Informa UK Limited},
-  author	= {Rea, Cristina and Granetz, Robert S.},
+  author	= {Rea, C and Granetz, R S},
   year		= {2018},
   month		= mar,
   pages		= {89–100}
@@ -209,8 +209,8 @@
   number	= {9},
   journal	= {Nuclear Fusion},
   publisher	= {IOP Publishing},
-  author	= {Rea, C. and Montes, K.J. and Erickson, K.G. and Granetz,
-		  R.S. and Tinguely, R.A.},
+  author	= {Rea, C and Montes, K J and Erickson, K G and Granetz,
+      R. S. and Tinguely, R. A.},
   year		= {2019},
   month		= jul,
   pages		= {096016}
@@ -226,7 +226,7 @@
   number	= {8},
   journal	= {Fusion Science and Technology},
   publisher	= {Informa UK Limited},
-  author	= {Rea, C. and Montes, K. J. and Pau, A. and Granetz, R. S.
+  author	= {Rea, C and Montes, K J and Pau, A and Granetz, R S.
 		  and Sauter, O.},
   year		= {2020},
   month		= sep,
@@ -234,12 +234,7 @@
 }
 
 @InProceedings{	  rea_2024,
-  author	= {Rea, Cristina and Trevisan, Gregorio Luigi and Stillerman,
-		  Joshua A and Wei, Yumou and Lane-Walsh, Stephen and Winkel,
-		  Mark and Jelenak, Aleksandar and Mordijck, Saskia and
-		  Kostadinova, Eva G and Diem, Stephanie J and Cummings,
-		  Nathan and Hollocombe, Jonathan and Murphy, Nicholas A and
-		  Pau, Alessandro and {MIT PSFC Disruption Studies Group}},
+  author	= {Rea, C and Trevisan, G L and Stillerman, J and Wei, Y and Lane-Walsh, S and Winkel, M and Jelenak, A and Mordijck, S and Kostadinova, E G and Diem, S J and Cummings, N and Hollocombe, J and Murphy, N A and Pau, A and {MIT PSFC Disruption Studies Group}}, 
   title		= {Open and FAIR Fusion for Machine Learning Applications},
   booktitle	= {Proceedings of the 2024 APS Division of Plasma Physics
 		  Meeting},
@@ -257,9 +252,9 @@
   doi		= {10.1016/j.fusengdes.2018.02.003},
   journal	= {Fusion Engineering and Design},
   publisher	= {Elsevier BV},
-  author	= {Sammuli, B.S. and Barr, J.L. and Eidietis, N.W. and
-		  Olofsson, K.E.J. and Flanagan, S.M. and Kostuk, M. and
-		  Humphreys, D.A.},
+  author	= {Sammuli, B. S. and Barr, J. L. and Eidietis, N. W. and
+      Olofsson, K. E. J. and Flanagan, S. M. and Kostuk, M. and
+      Humphreys, D. A.},
   year		= {2018},
   month		= apr,
   pages		= {12–15}
@@ -275,8 +270,8 @@
   number	= {11},
   journal	= {Nuclear Fusion},
   publisher	= {IOP Publishing},
-  author	= {Saperstein, A.R. and Rea, C. and Sweeney, R. and Boyer,
-		  M.D. and Trevisan, G.L. and Wei, Y.},
+  author	= {Saperstein, A. R. and Rea, Cristina and Sweeney, R. and Boyer,
+      M. D. and Trevisan, G. L. and Wei, Y.},
   year		= {2025},
   month		= oct,
   pages		= {116007}
@@ -310,8 +305,8 @@
   number	= {1},
   journal	= {Review of Scientific Instruments},
   publisher	= {AIP Publishing},
-  author	= {Stillerman, J. A. and Fredian, T. W. and Klare, K.A. and
-		  Manduchi, G.},
+  author	= {Stillerman, J. and Fredian, T. W. and Klare, K. A. and
+      Manduchi, G.},
   year		= {1997},
   month		= jan,
   pages		= {939–942}
@@ -326,9 +321,9 @@
   doi		= {10.1016/j.fusengdes.2024.114770},
   journal	= {Fusion Engineering and Design},
   publisher	= {Elsevier BV},
-  author	= {Stillerman, Joshua and Lane-Walsh, Stephen and Winkel,
-		  Mark and Rea, Cristina and Trevisan, Gregorio Luigi and
-		  Jelenak, Aleksandar and Readey, John},
+  author	= {Stillerman, J. and Lane-Walsh, Stephen and Winkel,
+      Mark and Rea, Cristina and Trevisan, Gregorio Luigi and
+      Jelenak, Aleksandar and Readey, John},
   year		= {2025},
   month		= feb,
   pages		= {114770}
@@ -411,9 +406,9 @@
 		  Bouwman, Jildau and Brookes, Anthony J. and Clark, Tim and
 		  Crosas, Mercè and Dillo, Ingrid and Dumon, Olivier and
 		  Edmunds, Scott and Evelo, Chris T. and Finkers, Richard and
-		  Gonzalez-Beltran, Alejandra and Gray, Alasdair J.G. and
+		  Gonzalez-Beltran, Alejandra and Gray, Alasdair J. G. and
 		  Groth, Paul and Goble, Carole and Grethe, Jeffrey S. and
-		  Heringa, Jaap and ’t Hoen, Peter A.C and Hooft, Rob and
+		  Heringa, Jaap and ’t Hoen, Peter A. C. and Hooft, Rob and
 		  Kuhn, Tobias and Kok, Ruben and Kok, Joost and Lusher,
 		  Scott J. and Martone, Maryann E. and Mons, Albert and
 		  Packer, Abel L. and Persson, Bengt and Rocca-Serra,
@@ -438,8 +433,8 @@
   number	= {2},
   journal	= {Nuclear Fusion},
   publisher	= {IOP Publishing},
-  author	= {Zhu, J.X. and Rea, C. and Montes, K. and Granetz, R.S. and
-		  Sweeney, R. and Tinguely, R.A.},
+  author	= {Zhu, J. X. and Rea, Cristina and Montes, K. and Granetz, R. S. and
+      Sweeney, R. and Tinguely, R. A.},
   year		= {2020},
   month		= dec,
   pages		= {026007}
@@ -455,9 +450,9 @@
   number	= {11},
   journal	= {Nuclear Fusion},
   publisher	= {IOP Publishing},
-  author	= {Zhu, J. and Rea, C. and Granetz, R.S. and Marmar, E.S. and
-		  Montes, K.J. and Sweeney, R. and Tinguely, R.A. and Chen,
-		  D.L. and Shen, B. and Xiao, B.J. and Humphreys, D. and
+  author	= {Zhu, J. and Rea, Cristina and Granetz, R. S. and Marmar, E. S. and
+      Montes, K. J. and Sweeney, R. and Tinguely, R. A. and Chen,
+      D. L. and Shen, B. and Xiao, B. J. and Humphreys, D. and
 		  Barr, J. and Meneghini, O.},
   year		= {2021},
   month		= oct,
@@ -475,8 +470,8 @@
   number	= {4},
   journal	= {Nuclear Fusion},
   publisher	= {IOP Publishing},
-  author	= {Zhu, J.X. and Rea, C. and Granetz, R.S. and Marmar, E.S.
-		  and Sweeney, R. and Montes, K. and Tinguely, R.A.},
+  author	= {Zhu, J. X. and Rea, Cristina and Granetz, R. S. and Marmar, E. S.
+      and Sweeney, R. and Montes, K. and Tinguely, R. A.},
   year		= {2023},
   month		= mar,
   pages		= {046009}


### PR DESCRIPTION
This fixes the issues with citation rendering due to inconsistent bibfile entries as part of JOSS review https://github.com/openjournals/joss-reviews/issues/9364

It is based off of 94b1f41e96b874ae15c52c55b951069deab1c2d3 so may need the authors to reset to this to enable merging.