### PR TITLE
Backend abstraction II: rename mds_conn to data_conn to reflect backend-agnostic DataConnection

### DIFF
--- a/disruption_py/core/physics_method/decorator.py
+++ b/disruption_py/core/physics_method/decorator.py
@@ -30,7 +30,7 @@ def physics_method(
     decorated method will be output to the `output_setting`.
 
     A common pattern for parameterized methods is first retrieving data from MDSplus
-    using the `mds_conn` and then using that retrieved data to compute data to return.
+    using the `data_conn` and then using that retrieved data to compute data to return.
 
     Parameters
     ----------

--- a/disruption_py/core/physics_method/decorator.py
+++ b/disruption_py/core/physics_method/decorator.py
@@ -29,9 +29,6 @@ def physics_method(
     `retrieval_settings` or in the built-in method list. If run, the result of the
     decorated method will be output to the `output_setting`.
 
-    A common pattern for parameterized methods is first retrieving data from MDSplus
-    using the `data_conn` and then using that retrieved data to compute data to return.
-
     Parameters
     ----------
     cache : bool, optional

--- a/disruption_py/core/physics_method/params.py
+++ b/disruption_py/core/physics_method/params.py
@@ -18,14 +18,14 @@ from disruption_py.machine.tokamak import Tokamak
 @dataclass
 class PhysicsMethodParams:
     """
-    Holder for useful variables for the physics methods like an MDSplus connection
+    Holder for useful variables for the physics methods like a data connection
     and the timebase for the data.
     """
 
     shot_id: int
     tokamak: Tokamak
     disruption_time: float
-    mds_conn: DataConnection
+    data_conn: DataConnection
     times: np.ndarray
 
     def __post_init__(self):
@@ -49,7 +49,7 @@ class PhysicsMethodParams:
         """
         Clean up resources used by the physics method parameters.
         """
-        self.mds_conn.cleanup()
+        self.data_conn.cleanup()
         self.times = None
         self.cached_results.clear()
 

--- a/disruption_py/core/physics_method/runner.py
+++ b/disruption_py/core/physics_method/runner.py
@@ -176,10 +176,12 @@ def populate_method(
     physics_method_params.logger.trace("Starting method: {name}", name=name)
 
     try:
+
         result = method(params=physics_method_params)
 
     # pylint: disable-next=broad-exception-caught
     except Exception as e:
+
         # log exception
         level = "ERROR"
         if isinstance(e, mdsExceptions.MDSplusERROR):
@@ -241,6 +243,7 @@ def populate_shot(
     start_time = time.time()
     datasets = []
     for bound_method_metadata in run_bound_method_metadata:
+
         # run method
         result = populate_method(
             physics_method_params=physics_method_params,
@@ -249,6 +252,7 @@ def populate_shot(
 
         # convert non-dataset dict to dataset
         if not isinstance(result, (xr.DataArray, xr.Dataset)):
+
             times = physics_method_params.times
 
             # create data_vars dict

--- a/disruption_py/core/physics_method/runner.py
+++ b/disruption_py/core/physics_method/runner.py
@@ -161,7 +161,7 @@ def populate_method(
     Parameters
     ----------
     physics_method_params : PhysicsMethodParams
-        Parameters containing MDS connection and shot information
+        Parameters containing data connection and shot information
     bound_method_metadata : BoundMethodMetadata
         The metadata for a physics method like the associated tokamak, columns, etc.
 
@@ -176,12 +176,10 @@ def populate_method(
     physics_method_params.logger.trace("Starting method: {name}", name=name)
 
     try:
-
         result = method(params=physics_method_params)
 
     # pylint: disable-next=broad-exception-caught
     except Exception as e:
-
         # log exception
         level = "ERROR"
         if isinstance(e, mdsExceptions.MDSplusERROR):
@@ -196,7 +194,7 @@ def populate_method(
 
         # reconnect if needed
         if isinstance(e, mdsExceptions.MDSplusERROR):
-            physics_method_params.mds_conn.reconnect()
+            physics_method_params.data_conn.reconnect()
 
     return result
 
@@ -243,7 +241,6 @@ def populate_shot(
     start_time = time.time()
     datasets = []
     for bound_method_metadata in run_bound_method_metadata:
-
         # run method
         result = populate_method(
             physics_method_params=physics_method_params,
@@ -252,7 +249,6 @@ def populate_shot(
 
         # convert non-dataset dict to dataset
         if not isinstance(result, (xr.DataArray, xr.Dataset)):
-
             times = physics_method_params.times
 
             # create data_vars dict

--- a/disruption_py/core/retrieval_manager.py
+++ b/disruption_py/core/retrieval_manager.py
@@ -30,7 +30,7 @@ class RetrievalManager:
         The tokamak instance.
     process_database : ShotDatabase
         The SQL database
-    process_mds_conn : ProcessConnection
+    process_data_conn : ProcessConnection
         The process-level data connection
     """
 
@@ -38,7 +38,7 @@ class RetrievalManager:
         self,
         tokamak: Tokamak,
         process_database: ShotDatabase,
-        process_mds_conn: ProcessConnection,
+        process_data_conn: ProcessConnection,
     ):
         """
         Parameters
@@ -47,12 +47,12 @@ class RetrievalManager:
             The tokamak instance.
         process_database : ShotDatabase
             The SQL database.
-        process_mds_conn : ProcessConnection
+        process_data_conn : ProcessConnection
             The process-level data connection.
         """
         self.tokamak = tokamak
         self.process_database = process_database
-        self.process_mds_conn = process_mds_conn
+        self.process_data_conn = process_data_conn
 
     def get_shot_data(
         self, shot_id, retrieval_settings: RetrievalSettings
@@ -101,7 +101,7 @@ class RetrievalManager:
                 shot_msg("Failed retrieval!"), shot=shot_id
             )
             if isinstance(e, mdsExceptions.MDSplusERROR):
-                physics_method_params.mds_conn.reconnect()
+                physics_method_params.data_conn.reconnect()
             retrieved_data = None
 
         # shot cleanup
@@ -112,7 +112,7 @@ class RetrievalManager:
             logger.critical(shot_msg("Failed cleanup! {e}"), shot=shot_id, e=repr(e))
             logger.opt(exception=True).debug(shot_msg("Failed cleanup!"), shot=shot_id)
             if isinstance(e, mdsExceptions.MDSplusERROR):
-                physics_method_params.mds_conn.reconnect()
+                physics_method_params.data_conn.reconnect()
             retrieved_data = None
 
         return retrieved_data
@@ -135,20 +135,20 @@ class RetrievalManager:
         Returns
         -------
         PhysicsMethodParams, or None
-            Parameters containing MDS connection and shot information
+            Parameters containing data connection and shot information
         """
 
         disruption_time = self.process_database.get_disruption_time(shot_id=shot_id)
 
-        mds_conn = self.process_mds_conn.get_shot_connection(shot_id=shot_id)
+        data_conn = self.process_data_conn.get_shot_connection(shot_id=shot_id)
 
-        if isinstance(mds_conn, MDSConnection):
-            mds_conn.add_tree_nickname_funcs(
+        if isinstance(data_conn, MDSConnection):
+            data_conn.add_tree_nickname_funcs(
                 tree_nickname_funcs={
                     "_efit_tree": lambda: retrieval_settings.efit_nickname_setting.get_tree_name(
                         NicknameSettingParams(
                             shot_id=shot_id,
-                            mds_conn=mds_conn,
+                            data_conn=data_conn,
                             database=self.process_database,
                             disruption_time=disruption_time,
                             tokamak=self.tokamak,
@@ -159,7 +159,7 @@ class RetrievalManager:
 
         physics_method_params = self.setup_physics_method_params(
             shot_id=shot_id,
-            mds_conn=mds_conn,
+            data_conn=data_conn,
             disruption_time=disruption_time,
             retrieval_settings=retrieval_settings,
             **kwargs,
@@ -181,14 +181,14 @@ class RetrievalManager:
         cls : type
             The class type.
         physics_method_params : PhysicsMethodParams
-            Parameters containing MDS connection and shot information.
+            Parameters containing data connection and shot information.
         """
         physics_method_params.cleanup()
 
     def setup_physics_method_params(
         self,
         shot_id: int,
-        mds_conn: DataConnection,
+        data_conn: DataConnection,
         disruption_time: float,
         retrieval_settings: RetrievalSettings,
     ) -> PhysicsMethodParams:
@@ -199,7 +199,7 @@ class RetrievalManager:
         ----------
         shot_id : int
             The ID of the shot.
-        mds_conn : DataConnection
+        data_conn : DataConnection
             The data connection for the shot.
         disruption_time : float
             The disruption time of the shot.
@@ -214,7 +214,7 @@ class RetrievalManager:
 
         times = self._init_times(
             shot_id=shot_id,
-            mds_conn=mds_conn,
+            data_conn=data_conn,
             disruption_time=disruption_time,
             retrieval_settings=retrieval_settings,
         )
@@ -223,7 +223,7 @@ class RetrievalManager:
             shot_id=shot_id,
             tokamak=self.tokamak,
             disruption_time=disruption_time,
-            mds_conn=mds_conn,
+            data_conn=data_conn,
             times=times,
         )
 
@@ -232,7 +232,7 @@ class RetrievalManager:
     def _init_times(
         self,
         shot_id: int,
-        mds_conn: DataConnection,
+        data_conn: DataConnection,
         disruption_time: float,
         retrieval_settings: RetrievalSettings,
     ) -> np.ndarray:
@@ -243,7 +243,7 @@ class RetrievalManager:
         ----------
         shot_id : int
             The ID of the shot.
-        mds_conn : DataConnection
+        data_conn : DataConnection
             The data connection for the shot.
         disruption_time : float
             The disruption time of the shot.
@@ -257,7 +257,7 @@ class RetrievalManager:
         """
         setting_params = TimeSettingParams(
             shot_id=shot_id,
-            mds_conn=mds_conn,
+            data_conn=data_conn,
             database=self.process_database,
             disruption_time=disruption_time,
             tokamak=self.tokamak,

--- a/disruption_py/machine/cmod/efit.py
+++ b/disruption_py/machine/cmod/efit.py
@@ -62,14 +62,14 @@ class CmodEfitMethods:
         Parameters
         ----------
         params : PhysicsMethodParams
-            The parameters containing the MDS connection and shot information.
+            The parameters containing the data connection and shot information.
 
         Returns
         -------
         dict
             A dictionary containing the retrieved EFIT parameters.
         """
-        efit_time = params.mds_conn.get_data(
+        efit_time = params.data_conn.get_data(
             r"\efit_aeqdsk:time", tree_name="_efit_tree"
         )  # [s]
         efit_data = {}
@@ -77,7 +77,7 @@ class CmodEfitMethods:
         # Get data from each of the columns in efit_cols one at a time
         for param, path in CmodEfitMethods.efit_cols.items():
             try:
-                efit_data[param] = params.mds_conn.get_data(
+                efit_data[param] = params.data_conn.get_data(
                     path=path,
                     tree_name="_efit_tree",
                 )
@@ -108,7 +108,7 @@ class CmodEfitMethods:
         Parameters
         ----------
         params : PhysicsMethodParams
-            The parameters containing the MDS connection and shot information.
+            The parameters containing the data connection and shot information.
 
         Returns
         -------
@@ -116,7 +116,7 @@ class CmodEfitMethods:
             A tuple containing valid indices and corresponding times.
         """
         values = [
-            params.mds_conn.get(expr, tree_name="analysis")
+            params.data_conn.get(expr, tree_name="analysis")
             for expr in [
                 r"_lf=\efit_aeqdsk:lflag",
                 r"_l0=((sum(_lf,1) - _lf[*,20] - _lf[*,1])==0)",
@@ -125,5 +125,7 @@ class CmodEfitMethods:
         ]
         _n = values[2].data()
         valid_indices = np.nonzero(_n)
-        (times,) = params.mds_conn.get_dims(r"\efit_aeqdsk:lflag", tree_name="analysis")
+        (times,) = params.data_conn.get_dims(
+            r"\efit_aeqdsk:lflag", tree_name="analysis"
+        )
         return valid_indices, times[valid_indices]

--- a/disruption_py/machine/cmod/physics.py
+++ b/disruption_py/machine/cmod/physics.py
@@ -1447,14 +1447,9 @@ class CmodPhysicsMethods:
         if use_ts_tci_calibration:
             # This shouldn't affect ne_PF (except if calib is not between 0.5 & 1.5)
             # because we're just multiplying ne by a constant
-            (
-                nl_ts1,
-                nl_ts2,
-                nl_tci1,
-                nl_tci2,
-                _,
-                _,
-            ) = CmodThomsonDensityMeasure.compare_ts_tci(params)
+            nl_ts1, nl_ts2, nl_tci1, nl_tci2, _, _ = (
+                CmodThomsonDensityMeasure.compare_ts_tci(params)
+            )
             if np.mean(nl_ts1) != 1e32 and np.mean(nl_ts2) != 1e32:
                 nl_tci = np.concatenate((nl_tci1, nl_tci2))
                 nl_ts = np.concatenate((nl_ts1 + nl_ts2))

--- a/disruption_py/machine/cmod/physics.py
+++ b/disruption_py/machine/cmod/physics.py
@@ -39,7 +39,7 @@ class CmodPhysicsMethods:
         Parameters
         ----------
         params : PhysicsMethodParams
-            The parameters containing the MDSplus connection and shot info.
+            The parameters containing the data connection and shot info.
 
         Returns
         -------
@@ -47,12 +47,12 @@ class CmodPhysicsMethods:
             A list of tuples, where each tuple contains the node path of the
             active segment and its start time. The list is sorted by start time.
         """
-        params.mds_conn.open_tree(tree_name="pcs")
-        root_nid = params.mds_conn.get("GetDefaultNid()")
-        children_nids = params.mds_conn.get(
+        params.data_conn.open_tree(tree_name="pcs")
+        root_nid = params.data_conn.get("GetDefaultNid()")
+        children_nids = params.data_conn.get(
             'getnci(getnci($, "CHILDREN_NIDS"), "NID_NUMBER")', arguments=root_nid
         )
-        children_paths = params.mds_conn.get(
+        children_paths = params.data_conn.get(
             'getnci($, "FULLPATH")', arguments=children_nids
         )
 
@@ -61,7 +61,7 @@ class CmodPhysicsMethods:
         for node_path in children_paths:
             node_path = node_path.strip()
             if node_path.split(".")[-1].startswith("SEG_"):
-                is_on = params.mds_conn.get_data(
+                is_on = params.data_conn.get_data(
                     'getnci($, "STATE")', arguments=f"{node_path}:SEG_NUM"
                 )
                 # 0 represents node being on, 1 represents node being off
@@ -70,7 +70,7 @@ class CmodPhysicsMethods:
                 active_segments.append(
                     (
                         node_path,
-                        params.mds_conn.get_data(
+                        params.data_conn.get_data(
                             f"{node_path}:start_time", tree_name="pcs"
                         ),
                     )
@@ -197,7 +197,7 @@ class CmodPhysicsMethods:
         Parameters
         ----------
         params : PhysicsMethodParams
-            The parameters containing the MDSplus connection, shot id and more.
+            The parameters containing the data connection, shot id and more.
 
         Returns
         -------
@@ -226,17 +226,17 @@ class CmodPhysicsMethods:
         for node_path, start in active_segments:
             # Ip wire can be one of 16 but is normally no. 16
             for wire_index in range(16, 0, -1):
-                wire_node_name = params.mds_conn.get_data(
+                wire_node_name = params.data_conn.get_data(
                     f"{node_path}:P_{wire_index:02d}:name", tree_name="pcs"
                 )
                 if wire_node_name == "IP":
                     try:
-                        pid_gains = params.mds_conn.get_data(
+                        pid_gains = params.data_conn.get_data(
                             f"{node_path}:P_{wire_index:02d}:pid_gains",
                             tree_name="pcs",
                         )
                         if np.any(pid_gains):
-                            signal, sigtime = params.mds_conn.get_data_with_dims(
+                            signal, sigtime = params.data_conn.get_data_with_dims(
                                 f"{node_path}:P_{wire_index:02d}", tree_name="pcs"
                             )
                             ip_prog_temp = interp1(
@@ -257,7 +257,7 @@ class CmodPhysicsMethods:
                         params.logger.warning(repr(e))
                         params.logger.opt(exception=True).debug(e)
                     break  # Break out of wire_index loop
-        ip, magtime = params.mds_conn.get_data_with_dims(
+        ip, magtime = params.data_conn.get_data_with_dims(
             r"\ip", tree_name="magnetics"
         )  # [A], [s]
         return CmodPhysicsMethods._get_ip_parameters(
@@ -354,7 +354,7 @@ class CmodPhysicsMethods:
         Parameters
         ----------
         params : PhysicsMethodParams
-            The parameters containing the MDSplus connection, shot id and more.
+            The parameters containing the data connection, shot id and more.
 
         Returns
         -------
@@ -380,17 +380,17 @@ class CmodPhysicsMethods:
 
         for node_path, start in active_wire_segments:
             for wire_index in range(1, 17):
-                wire_node_name = params.mds_conn.get_data(
+                wire_node_name = params.data_conn.get_data(
                     f"{node_path}:P_{wire_index:02d}:name", tree_name="pcs"
                 )
                 if wire_node_name == "ZCUR":
                     try:
-                        pid_gains = params.mds_conn.get_data(
+                        pid_gains = params.data_conn.get_data(
                             f"{node_path}:P_{wire_index:02d}:pid_gains",
                             tree_name="pcs",
                         )
                         if np.any(pid_gains):
-                            signal, sigtime = params.mds_conn.get_data_with_dims(
+                            signal, sigtime = params.data_conn.get_data_with_dims(
                                 f"{node_path}:P_{wire_index:02d}", tree_name="pcs"
                             )
                             end = sigtime[
@@ -421,7 +421,7 @@ class CmodPhysicsMethods:
             raise CalculationError("Data source error: No ZCUR wire was found")
         # Read in A_OUT, which is a 16xN matrix of the errors for *all* 16 wires for
         # *all* of the segments. Note that DPCS time is usually taken at 10kHz.
-        wire_errors, dpcstime = params.mds_conn.get_data_with_dims(
+        wire_errors, dpcstime = params.data_conn.get_data_with_dims(
             r"\top.hardware.dpcs.signals:a_out", tree_name="hybrid", dim_nums=[1]
         )
         # The value of Z_error we read is not in the units we want. It must be *divided*
@@ -438,7 +438,7 @@ class CmodPhysicsMethods:
             else:
                 end = active_wire_segments[i + 1][1]
             # DPCS refers to PCS so we need to open the common ancestor tree, HYBRID
-            z_factor = params.mds_conn.get_data(
+            z_factor = params.data_conn.get_data(
                 rf"\dpcs::top.seg_{i + 1:02d}:p_{z_wire_index:02d}:predictor:factor",
                 tree_name="hybrid",
             )
@@ -452,16 +452,16 @@ class CmodPhysicsMethods:
         # before 2015.
         # TODO: Try to fix this
         if params.shot_id > 1150101000:
-            ip_without_factor = params.mds_conn.get_data(
+            ip_without_factor = params.data_conn.get_data(
                 r"\top.hardware.dpcs.signals.a_in:input_056", tree_name="hybrid"
             )
-            ip_factor = params.mds_conn.get_data(
+            ip_factor = params.data_conn.get_data(
                 r"\top.dpcs_config.inputs:input_056:p_to_v_expr",
                 tree_name="hybrid",
             )
             ip = ip_without_factor * ip_factor  # [A]
         else:
-            ip, ip_time = params.mds_conn.get_data_with_dims(
+            ip, ip_time = params.data_conn.get_data_with_dims(
                 r"\ip", tree_name="magnetics"
             )  # [A], [s]
             ip = interp1(ip_time, ip, dpcstime)
@@ -527,7 +527,7 @@ class CmodPhysicsMethods:
         Parameters
         ----------
         params : PhysicsMethodParams
-            The parameters containing the MDSplus connection, shot id and more.
+            The parameters containing the data connection, shot id and more.
 
         Returns
         -------
@@ -542,7 +542,7 @@ class CmodPhysicsMethods:
         - pull requests: #[367](https://github.com/MIT-PSFC/disruption-py/pull/367)
         """
         try:
-            v_loop, v_loop_time = params.mds_conn.get_data_with_dims(
+            v_loop, v_loop_time = params.data_conn.get_data_with_dims(
                 r"\top.mflux:v0", tree_name="analysis"
             )  # [V], [s]
             # Apply 6-point boxcar smoothing to raw vloop signal.
@@ -552,17 +552,17 @@ class CmodPhysicsMethods:
             params.logger.verbose(
                 r"v_loop: Failed to get \top.mflux:v0 data. Use \efit_aeqdsk:vloopt instead."
             )
-            v_loop, v_loop_time = params.mds_conn.get_data_with_dims(
+            v_loop, v_loop_time = params.data_conn.get_data_with_dims(
                 r"\efit_aeqdsk:vloopt", tree_name="_efit_tree"
             )  # [V], [s]
         if len(v_loop_time) <= 1:
             raise CalculationError("No data for v_loop_time")
 
-        li, efittime = params.mds_conn.get_data_with_dims(
+        li, efittime = params.data_conn.get_data_with_dims(
             r"\efit_aeqdsk:ali", tree_name="_efit_tree"
         )  # [dimensionless], [s]
         ip_parameters = CmodPhysicsMethods.get_ip_parameters(params=params)
-        r0 = params.mds_conn.get_data(
+        r0 = params.data_conn.get_data(
             r"\efit_aeqdsk:rmagx/100", tree_name="_efit_tree"
         )  # [m]
 
@@ -711,7 +711,7 @@ class CmodPhysicsMethods:
         Parameters
         ----------
         params : PhysicsMethodParams
-            The parameters containing the MDSplus connection, shot id and more.
+            The parameters containing the data connection, shot id and more.
 
         Returns
         -------
@@ -739,7 +739,7 @@ class CmodPhysicsMethods:
             p = f"p_{val}"
             t = f"t_{val}"
             try:
-                kwa[p], kwa[t] = params.mds_conn.get_data_with_dims(
+                kwa[p], kwa[t] = params.data_conn.get_data_with_dims(
                     node, tree_name=tree
                 )
             except (mdsExceptions.TreeFOPENR, mdsExceptions.TreeNNF):
@@ -751,7 +751,7 @@ class CmodPhysicsMethods:
         except mdsExceptions.TreeException:
             kwa["p_ohm"] = np.full(len(params.times), np.nan)
         # Plasma magnetic energy, and respective time base
-        kwa["wmhd"], kwa["efit_time"] = params.mds_conn.get_data_with_dims(
+        kwa["wmhd"], kwa["efit_time"] = params.data_conn.get_data_with_dims(
             r"\efit_aeqdsk:wplasm", tree_name="_efit_tree"
         )  # [J], [s]
         return CmodPhysicsMethods._get_power(params.times, **kwa)
@@ -795,7 +795,7 @@ class CmodPhysicsMethods:
         Parameters
         ----------
         params : PhysicsMethodParams
-            The parameters containing the MDSplus connection, shot id and more.
+            The parameters containing the data connection, shot id and more.
 
         Returns
         -------
@@ -807,13 +807,13 @@ class CmodPhysicsMethods:
         - original source: [get_kappa_area.m](https://github.com/MIT-PSFC/disruption-py/
         blob/matlab/CMOD/matlab-core/get_kappa_area.m)
         """
-        aminor = params.mds_conn.get_data(
+        aminor = params.data_conn.get_data(
             r"\efit_aeqdsk:aout/100", tree_name="_efit_tree"
         )  # [m]
-        area = params.mds_conn.get_data(
+        area = params.data_conn.get_data(
             r"\efit_aeqdsk:areao/1e4", tree_name="_efit_tree"
         )  # [m^2]
-        times = params.mds_conn.get_data(
+        times = params.data_conn.get_data(
             r"\efit_aeqdsk:time", tree_name="_efit_tree"
         )  # [s]
 
@@ -866,7 +866,7 @@ class CmodPhysicsMethods:
         Parameters
         ----------
         params : PhysicsMethodParams
-            The parameters containing the MDSplus connection, shot id and more.
+            The parameters containing the data connection, shot id and more.
 
         Returns
         -------
@@ -891,11 +891,11 @@ class CmodPhysicsMethods:
         a = []
 
         path = r"\mag_bp_coils."
-        bp_node_names = params.mds_conn.get_data(
+        bp_node_names = params.data_conn.get_data(
             f"{path}nodename", tree_name="magnetics"
         )
-        phi = params.mds_conn.get_data(f"{path}phi", tree_name="magnetics")  # [degree]
-        btor_pickup_coeffs = params.mds_conn.get_data(
+        phi = params.data_conn.get_data(f"{path}phi", tree_name="magnetics")  # [degree]
+        btor_pickup_coeffs = params.data_conn.get_data(
             f"{path}btor_pickup", tree_name="magnetics"
         )  # [dimensionless]
         _, bp13_indices, _ = np.intersect1d(
@@ -903,7 +903,7 @@ class CmodPhysicsMethods:
         )
         bp13_phi = phi[bp13_indices] + 360  # INFO
         bp13_btor_pickup_coeffs = btor_pickup_coeffs[bp13_indices]
-        btor, t_mag = params.mds_conn.get_data_with_dims(
+        btor, t_mag = params.data_conn.get_data_with_dims(
             r"\btor", tree_name="magnetics"
         )  # [T], [s]
         # Toroidal power supply takes time to turn on, from ~ -1.8 and should be
@@ -918,7 +918,7 @@ class CmodPhysicsMethods:
 
         for i, bp13_name in enumerate(bp13_names):
             try:
-                signal = params.mds_conn.get_data(
+                signal = params.data_conn.get_data(
                     path + bp13_name, tree_name="magnetics"
                 )  # [T]
             # Sensor not available, skip
@@ -1055,7 +1055,7 @@ class CmodPhysicsMethods:
         Parameters
         ----------
         params : PhysicsMethodParams
-            The parameters containing the MDSplus connection, shot id and more.
+            The parameters containing the data connection, shot id and more.
 
         Returns
         -------
@@ -1069,17 +1069,17 @@ class CmodPhysicsMethods:
         matlab/CMOD/matlab-core/get_densities.m)
         """
         # Line-integrated density
-        n_e, t_n = params.mds_conn.get_data_with_dims(
+        n_e, t_n = params.data_conn.get_data_with_dims(
             r".tci.results:nl_04", tree_name="electrons"
         )  # [m^-3], [s]
         # Divide by chord length of ~0.6m to get line averaged density.
         # For future refernce, chord length is stored in
         # .01*\analysis::efit_aeqdsk:rco2v[3,*]
         n_e = np.squeeze(n_e) / 0.6
-        ip, t_ip = params.mds_conn.get_data_with_dims(
+        ip, t_ip = params.data_conn.get_data_with_dims(
             r"\ip", tree_name="magnetics"
         )  # [A], [s]
-        a_minor, t_a = params.mds_conn.get_data_with_dims(
+        a_minor, t_a = params.data_conn.get_data_with_dims(
             r"\efit_aeqdsk:aout/100", tree_name="_efit_tree"
         )  # [m], [s]
 
@@ -1117,7 +1117,7 @@ class CmodPhysicsMethods:
         Parameters
         ----------
         params : PhysicsMethodParams
-            Parameters containing MDS connection and shot information.
+            Parameters containing data connection and shot information.
 
         Returns
         -------
@@ -1129,7 +1129,7 @@ class CmodPhysicsMethods:
         - original source: [get_efc_current.m](https://github.com/MIT-PSFC/disruption-py/
         blob/matlab/CMOD/matlab-core/get_efc_current.m)
         """
-        iefc, t_iefc = params.mds_conn.get_data_with_dims(
+        iefc, t_iefc = params.data_conn.get_data_with_dims(
             r"\efc:u_bus_r_cur", tree_name="engineering"
         )  # [A], [s]
         return CmodPhysicsMethods._get_efc_current(params.times, iefc, t_iefc)
@@ -1222,7 +1222,7 @@ class CmodPhysicsMethods:
         Parameters
         ----------
         params : PhysicsMethodParams
-            Parameters containing MDS connection and shot information.
+            Parameters containing data connection and shot information.
 
         Returns
         -------
@@ -1243,13 +1243,13 @@ class CmodPhysicsMethods:
         # dependent dimensions being time and z (vertical coordinate)
         node_path = ".yag_new.results.profiles"
 
-        ts_data, ts_time = params.mds_conn.get_data_with_dims(
+        ts_data, ts_time = params.data_conn.get_data_with_dims(
             f"{node_path}:te_rz", tree_name="electrons"
         )  # [keV], [s]
-        ts_z = params.mds_conn.get_data(
+        ts_z = params.data_conn.get_data(
             f"{node_path}:z_sorted", tree_name="electrons"
         )  # [m]
-        ts_error = params.mds_conn.get_data(
+        ts_error = params.data_conn.get_data(
             f"{node_path}:te_err", tree_name="electrons"
         )  # [keV]
 
@@ -1381,7 +1381,7 @@ class CmodPhysicsMethods:
         Parameters
         ----------
         params : PhysicsMethodParams
-            The parameters containing the MDSplus connection, shot id and more.
+            The parameters containing the data connection, shot id and more.
 
         Returns
         -------
@@ -1404,38 +1404,38 @@ class CmodPhysicsMethods:
             raise CalculationError("Shot is on blacklist")
         # Fetch data
         # Get EFIT geometry data
-        z0 = params.mds_conn.get_data(
+        z0 = params.data_conn.get_data(
             r"\efit_aeqdsk:zmagx/100", tree_name="_efit_tree"
         )  # [m]
-        kappa = params.mds_conn.get_data(
+        kappa = params.data_conn.get_data(
             r"\efit_aeqdsk:kappa", tree_name="_efit_tree"
         )  # [dimensionless]
-        aminor, efit_time = params.mds_conn.get_data_with_dims(
+        aminor, efit_time = params.data_conn.get_data_with_dims(
             r"\efit_aeqdsk:aout/100", tree_name="_efit_tree"
         )  # [m], [s]
         bminor = aminor * kappa
 
         # Get Te data and TS time basis
         node_ext = ".yag_new.results.profiles"
-        ts_te_core, ts_time = params.mds_conn.get_data_with_dims(
+        ts_te_core, ts_time = params.data_conn.get_data_with_dims(
             f"{node_ext}:te_rz", tree_name="electrons"
         )  # [keV], [s]
         ts_te_core = ts_te_core * 1000  # [keV] -> [eV]
-        ts_te_edge = params.mds_conn.get_data(r"\ts_te")  # [eV]
+        ts_te_edge = params.data_conn.get_data(r"\ts_te")  # [eV]
         ts_te = np.concatenate((ts_te_core, ts_te_edge)) * 11600  # [eV] -> [K]
 
         # Get ne data
-        ts_ne_core = params.mds_conn.get_data(
+        ts_ne_core = params.data_conn.get_data(
             f"{node_ext}:ne_rz", tree_name="electrons"
         )  # [m^-3]
-        ts_ne_edge = params.mds_conn.get_data(r"\ts_ne")  # [m^-3]
+        ts_ne_edge = params.data_conn.get_data(r"\ts_ne")  # [m^-3]
         ts_ne = np.concatenate((ts_ne_core, ts_ne_edge))
 
         # Get TS chord positions
-        ts_z_core = params.mds_conn.get_data(
+        ts_z_core = params.data_conn.get_data(
             f"{node_ext}:z_sorted", tree_name="electrons"
         )  # [m]
-        ts_z_edge = params.mds_conn.get_data(r"\fiber_z", tree_name="electrons")  # [m]
+        ts_z_edge = params.data_conn.get_data(r"\fiber_z", tree_name="electrons")  # [m]
         ts_z = np.concatenate((ts_z_core, ts_z_edge))
         # Make sure that there are equal numbers of edge position and edge temperature points
         if len(ts_z_edge) != ts_te_edge.shape[0]:
@@ -1447,9 +1447,14 @@ class CmodPhysicsMethods:
         if use_ts_tci_calibration:
             # This shouldn't affect ne_PF (except if calib is not between 0.5 & 1.5)
             # because we're just multiplying ne by a constant
-            nl_ts1, nl_ts2, nl_tci1, nl_tci2, _, _ = (
-                CmodThomsonDensityMeasure.compare_ts_tci(params)
-            )
+            (
+                nl_ts1,
+                nl_ts2,
+                nl_tci1,
+                nl_tci2,
+                _,
+                _,
+            ) = CmodThomsonDensityMeasure.compare_ts_tci(params)
             if np.mean(nl_ts1) != 1e32 and np.mean(nl_ts2) != 1e32:
                 nl_tci = np.concatenate((nl_tci1, nl_tci2))
                 nl_ts = np.concatenate((nl_ts1 + nl_ts2))
@@ -1775,7 +1780,7 @@ class CmodPhysicsMethods:
         Parameters
         ----------
         params : PhysicsMethodParams
-            The parameters containing the MDSplus connection, shot id and more.
+            The parameters containing the data connection, shot id and more.
 
         Returns
         ----------
@@ -1793,19 +1798,19 @@ class CmodPhysicsMethods:
         """
 
         # Get magnetic axis data from EFIT
-        r0 = params.mds_conn.get_data(
+        r0 = params.data_conn.get_data(
             r"\efit_aeqdsk:rmagx/100", tree_name="_efit_tree"
         )  # [m]
-        aminor, efit_time = params.mds_conn.get_data_with_dims(
+        aminor, efit_time = params.data_conn.get_data_with_dims(
             r"\efit_aeqdsk:aout/100", tree_name="_efit_tree"
         )  # [m], [s]
 
         # Btor and LH Power used for filtering okay time slices
-        btor, t_mag = params.mds_conn.get_data_with_dims(
+        btor, t_mag = params.data_conn.get_data_with_dims(
             r"\btor", tree_name="magnetics"
         )  # [T], [s]
         try:
-            lh_power, lh_time = params.mds_conn.get_data_with_dims(
+            lh_power, lh_time = params.data_conn.get_data_with_dims(
                 ".results:netpow", tree_name="lh"
             )  # [kW], [s]
         except mdsExceptions.MdsException:
@@ -1817,15 +1822,15 @@ class CmodPhysicsMethods:
 
         # Read in Te profile measurements from GPC2 (19 channels)
         node_path = ".gpc_2.results"
-        gpc2_te_data, gpc2_te_time = params.mds_conn.get_data_with_dims(
+        gpc2_te_data, gpc2_te_time = params.data_conn.get_data_with_dims(
             f"{node_path}:gpc2_te", tree_name="electrons"
         )  # [keV], [s]
-        gpc2_rad_data, gpc2_rad_time = params.mds_conn.get_data_with_dims(
+        gpc2_rad_data, gpc2_rad_time = params.data_conn.get_data_with_dims(
             f"{node_path}:radii", tree_name="electrons"
         )  # [m], [s]
         # Te0 from GPC2 useful to check for outliers in the GPC channels
         # which be caused by some artifact or systematic error
-        gpc2_te0 = params.mds_conn.get_data(r"\gpc2_te0", tree_name="electrons")
+        gpc2_te0 = params.data_conn.get_data(r"\gpc2_te0", tree_name="electrons")
         # Line average density [m^-3] to check for cutoffs
         densities = CmodPhysicsMethods.get_densities(params)
         n_e = densities["n_e"]
@@ -1858,7 +1863,7 @@ class CmodPhysicsMethods:
         Parameters
         ----------
         params : PhysicsMethodParams
-            The parameters containing the MDSplus connection, shot id and more.
+            The parameters containing the data connection, shot id and more.
 
         Returns
         -------
@@ -1878,27 +1883,27 @@ class CmodPhysicsMethods:
         """
         prad_peaking = np.full(len(params.times), np.nan)
         nan_output = {"prad_peaking": prad_peaking}
-        r0 = params.mds_conn.get_data(
+        r0 = params.data_conn.get_data(
             r"\efit_aeqdsk:rmagx/100", tree_name="_efit_tree"
         )  # [m]
-        z0 = params.mds_conn.get_data(
+        z0 = params.data_conn.get_data(
             r"\efit_aeqdsk:zmagx/100", tree_name="_efit_tree"
         )  # [m]
-        aminor, efit_time = params.mds_conn.get_data_with_dims(
+        aminor, efit_time = params.data_conn.get_data_with_dims(
             r"\efit_aeqdsk:aout/100", tree_name="_efit_tree"
         )  # [m], [s]
         got_axa = False
         try:
-            bright_axa, t_axa, r_axa = params.mds_conn.get_data_with_dims(
+            bright_axa, t_axa, r_axa = params.data_conn.get_data_with_dims(
                 r"\TOP.BOLOMETER.RESULTS.DIODE.AXA:BRIGHT",
                 tree_name="spectroscopy",
                 dim_nums=[1, 0],
             )  # [W/m^2], [s], [m]
-            z_axa = params.mds_conn.get_data(
+            z_axa = params.data_conn.get_data(
                 r"\TOP.BOLOMETER.DIODE_CALIB.AXA:Z_O",
                 tree_name="spectroscopy",
             )  # [m]
-            good_axa = params.mds_conn.get_data(
+            good_axa = params.data_conn.get_data(
                 r"\TOP.BOLOMETER.DIODE_CALIB.AXA:GOOD",
                 tree_name="spectroscopy",
             )  # [index]
@@ -1907,16 +1912,16 @@ class CmodPhysicsMethods:
             params.logger.debug("Failed to get AXA data")
         got_axj = False
         try:
-            bright_axj, t_axj, r_axj = params.mds_conn.get_data_with_dims(
+            bright_axj, t_axj, r_axj = params.data_conn.get_data_with_dims(
                 r"\TOP.BOLOMETER.RESULTS.DIODE.AXJ:BRIGHT",
                 tree_name="spectroscopy",
                 dim_nums=[1, 0],
             )  # [W/m^2], [s], [m]
-            z_axj = params.mds_conn.get_data(
+            z_axj = params.data_conn.get_data(
                 r"\TOP.BOLOMETER.DIODE_CALIB.AXJ:Z_O",
                 tree_name="spectroscopy",
             )  # [m]
-            good_axj = params.mds_conn.get_data(
+            good_axj = params.data_conn.get_data(
                 r"\TOP.BOLOMETER.DIODE_CALIB.AXJ:GOOD",
                 tree_name="spectroscopy",
             )  # [index]
@@ -1980,7 +1985,7 @@ class CmodPhysicsMethods:
         Parameters
         ----------
         params : PhysicsMethodParams
-            The parameters containing the MDSplus connection, shot id and more.
+            The parameters containing the data connection, shot id and more.
 
         Returns
         -------
@@ -1993,7 +1998,7 @@ class CmodPhysicsMethods:
         blob/matlab/CMOD/matlab-core/get_sxr_data.m)
 
         """
-        sxr, t_sxr = params.mds_conn.get_data_with_dims(
+        sxr, t_sxr = params.data_conn.get_data_with_dims(
             r"\top.brightnesses.array_1:chord_16",
             tree_name="xtomo",
         )  # [W/m^2], [s]
@@ -2033,7 +2038,7 @@ class CmodPhysicsMethods:
         Parameters
         ----------
         params : PhysicsMethodParams
-            The parameters containing the MDSplus connection, shot id and more.
+            The parameters containing the data connection, shot id and more.
 
         Returns
         -------
@@ -2046,16 +2051,16 @@ class CmodPhysicsMethods:
 
         """
         # Get signals from EFIT tree
-        beta_t, efittime = params.mds_conn.get_data_with_dims(
+        beta_t, efittime = params.data_conn.get_data_with_dims(
             r"\efit_aeqdsk:betat", tree_name="_efit_tree"
         )  # [%], [s]
-        ip = params.mds_conn.get_data(
+        ip = params.data_conn.get_data(
             r"\efit_aeqdsk:cpasma/1e6", tree_name="_efit_tree"
         )  # [MA]
-        aminor = params.mds_conn.get_data(
+        aminor = params.data_conn.get_data(
             r"\efit_aeqdsk:aout/100", tree_name="_efit_tree"
         )  # [m]
-        btor = params.mds_conn.get_data(
+        btor = params.data_conn.get_data(
             r"\efit_aeqdsk:btaxp", tree_name="_efit_tree"
         )  # [T]
 
@@ -2084,7 +2089,7 @@ class CmodPhysicsMethods:
         Parameters
         ----------
         params : PhysicsMethodParams
-            The parameters containing the MDSplus connection, shot id and more.
+            The parameters containing the data connection, shot id and more.
 
         Returns
         -------
@@ -2106,7 +2111,7 @@ class CmodPhysicsMethods:
         are zeros for every shot.
         """
         # Get signals from EFIT tree
-        sibdry, efit_time = params.mds_conn.get_data_with_dims(
+        sibdry, efit_time = params.data_conn.get_data_with_dims(
             r"\efit_aeqdsk:sibdry", tree_name="_efit_tree"
         )  # [V*s/rad], [s]
 

--- a/disruption_py/machine/cmod/thomson.py
+++ b/disruption_py/machine/cmod/thomson.py
@@ -25,7 +25,7 @@ class CmodThomsonDensityMeasure:
         Parameters
         ----------
         params : PhysicsMethodParams
-            Parameters containing MDS connection and shot information.
+            Parameters containing data connection and shot information.
         nlnum : int, optional
             The number of the TCI channel to compare (default is 4).
 
@@ -40,10 +40,10 @@ class CmodThomsonDensityMeasure:
         nl_tci2 = [1e32]
         ts_time1 = [1e32]
         ts_time2 = [1e32]
-        (tci_time,) = params.mds_conn.get_dims(
+        (tci_time,) = params.data_conn.get_dims(
             ".YAG_NEW.RESULTS.PROFILES:NE_RZ", tree_name="electrons"
         )
-        tci, tci_t = params.mds_conn.get_data_with_dims(
+        tci, tci_t = params.data_conn.get_data_with_dims(
             f".TCI.RESULTS:NL_{nlnum:02d}", tree_name="electrons"
         )
         nlts, nlts_t = CmodThomsonDensityMeasure._integrate_ts_tci(params, nlnum)
@@ -75,19 +75,19 @@ class CmodThomsonDensityMeasure:
         Parameters
         ----------
         params : PhysicsMethodParams
-            Parameters containing MDS connection and shot information.
+            Parameters containing data connection and shot information.
 
         Returns
         -------
         tuple
             Tuple containing the number of YAGs and their indices.
         """
-        nyag1 = params.mds_conn.get_data(r"\knobs:pulses_q", tree_name="electrons")
-        nyag2 = params.mds_conn.get_data(r"\knobs:pulses_q_2", tree_name="electrons")
+        nyag1 = params.data_conn.get_data(r"\knobs:pulses_q", tree_name="electrons")
+        nyag2 = params.data_conn.get_data(r"\knobs:pulses_q_2", tree_name="electrons")
         indices1 = -1
         indices2 = -1
-        dark = params.mds_conn.get_data(r"\n_dark_prior", tree_name="electrons")
-        ntotal = params.mds_conn.get_data(r"\n_total", tree_name="electrons")
+        dark = params.data_conn.get_data(r"\n_dark_prior", tree_name="electrons")
+        ntotal = params.data_conn.get_data(r"\n_total", tree_name="electrons")
         nt = ntotal - dark
         if nyag1 == 0:
             if nyag2 != 0:
@@ -128,7 +128,7 @@ class CmodThomsonDensityMeasure:
         Parameters
         ----------
         params : PhysicsMethodParams
-            Parameters containing MDS connection and shot information.
+            Parameters containing data connection and shot information.
         nlnum : int
             The number of the TCI channel to integrate.
 
@@ -168,7 +168,7 @@ class CmodThomsonDensityMeasure:
         Parameters
         ----------
         params : PhysicsMethodParams
-            Parameters containing MDS connection and shot information.
+            Parameters containing data connection and shot information.
         nlnum : int
             The number of the TCI channel to map.
 
@@ -185,39 +185,39 @@ class CmodThomsonDensityMeasure:
         n_e_sig = [1e32]
         flag = 1
         valid_indices, efit_times = CmodEfitMethods.efit_check(params)
-        ip = params.mds_conn.get_data(r"\ip", "cmod")
+        ip = params.data_conn.get_data(r"\ip", "cmod")
         if np.mean(ip) > 0:
             flag = 0
-        efit_times = params.mds_conn.get_data(
+        efit_times = params.data_conn.get_data(
             r"\efit_aeqdsk:time", tree_name="_efit_tree"
         )
         t1 = np.amin(efit_times)
         t2 = np.amax(efit_times)
-        psia, psia_t = params.mds_conn.get_data_with_dims(
+        psia, psia_t = params.data_conn.get_data_with_dims(
             r"\efit_aeqdsk:SIBDRY", tree_name="_efit_tree"
         )
-        psi_0 = params.mds_conn.get(r"\efit_aeqdsk:SIMAGX", tree_name="_efit_tree")
-        nets_core, nets_core_t = params.mds_conn.get_data_with_dims(
+        psi_0 = params.data_conn.get(r"\efit_aeqdsk:SIMAGX", tree_name="_efit_tree")
+        nets_core, nets_core_t = params.data_conn.get_data_with_dims(
             ".YAG_NEW.RESULTS.PROFILES:NE_RZ", tree_name="electrons"
         )
-        nets_core_err = params.mds_conn.get_data(
+        nets_core_err = params.data_conn.get_data(
             ".YAG_NEW.RESULTS.PROFILES:NE_ERR", tree_name="electrons"
         )
-        zts_core = params.mds_conn.get_data(
+        zts_core = params.data_conn.get_data(
             ".YAG_NEW.RESULTS.PROFILES:Z_SORTED", tree_name="electrons"
         )
         mts_core = len(zts_core)
-        zts_edge = params.mds_conn.get_data(r"\fiber_z")
+        zts_edge = params.data_conn.get_data(r"\fiber_z")
         mts_edge = len(zts_edge)
         try:
-            nets_edge = params.mds_conn.get_data(r"\ts_ne")
-            nets_edge_err = params.mds_conn.get_data(r"\ts_ne_err")
+            nets_edge = params.data_conn.get_data(r"\ts_ne")
+            nets_edge_err = params.data_conn.get_data(r"\ts_ne_err")
         except mdsExceptions.MdsException:
             nets_edge = np.zeros((len(nets_core[:, 1]), mts_edge))
             nets_edge_err = nets_edge + 1e20
         mts = mts_core + mts_edge
-        rts = params.mds_conn.get(".YAG.RESULTS.PARAM:R") + np.zeros((1, mts))
-        rtci = params.mds_conn.get_data(".tci.results:rad")
+        rts = params.data_conn.get(".YAG.RESULTS.PARAM:R") + np.zeros((1, mts))
+        rtci = params.data_conn.get_data(".tci.results:rad")
         nts = len(nets_core_t)
         zts = np.zeros((1, mts))
         zts[:, :mts_core] = zts_core
@@ -278,7 +278,7 @@ class CmodThomsonDensityMeasure:
         Parameters
         ----------
         params : PhysicsMethodParams
-            Parameters containing MDS connection and shot information.
+            Parameters containing data connection and shot information.
         r : array_like
             Radial coordinates.
         z : array_like
@@ -296,7 +296,7 @@ class CmodThomsonDensityMeasure:
         r = r.flatten()
         z = z.flatten()
         psi = np.full((len(r), len(t)), np.nan)
-        psirz, rgrid, zgrid, times = params.mds_conn.get_data_with_dims(
+        psirz, rgrid, zgrid, times = params.data_conn.get_data_with_dims(
             r"\efit_geqdsk:psirz", tree_name=tree, dim_nums=[0, 1, 2]
         )
         rgrid, zgrid = np.meshgrid(rgrid, zgrid)

--- a/disruption_py/machine/d3d/efit.py
+++ b/disruption_py/machine/d3d/efit.py
@@ -53,7 +53,7 @@ class D3DEfitMethods:
         Parameters
         ----------
         params : PhysicsMethodParams
-            Parameters containing MDS connection and shot information.
+            Parameters containing data connection and shot information.
 
         Returns
         -------
@@ -61,11 +61,11 @@ class D3DEfitMethods:
             A dictionary containing the EFIT parameters and their derivatives.
         """
         efit_data = {
-            k: params.mds_conn.get_data(v, tree_name="_efit_tree")
+            k: params.data_conn.get_data(v, tree_name="_efit_tree")
             for k, v in D3DEfitMethods.efit_cols.items()
         }
         efit_time = (
-            params.mds_conn.get_data(r"\efit_a_eqdsk:atime", tree_name="_efit_tree")
+            params.data_conn.get_data(r"\efit_a_eqdsk:atime", tree_name="_efit_tree")
             / 1.0e3
         )  # [ms] -> [s]
 
@@ -100,7 +100,7 @@ class D3DEfitMethods:
         Parameters
         ----------
         params : PhysicsMethodParams
-            Parameters containing MDS connection and shot information.
+            Parameters containing data connection and shot information.
 
         Returns
         -------
@@ -108,11 +108,11 @@ class D3DEfitMethods:
             A dictionary containing the real-time EFIT parameters.
         """
         efit_data = {
-            k: params.mds_conn.get_data(v, tree_name="efitrt1")
+            k: params.data_conn.get_data(v, tree_name="efitrt1")
             for k, v in D3DEfitMethods.rt_efit_cols.items()
         }
         efit_time = (
-            params.mds_conn.get_data(r"\efit_a_eqdsk:atime", tree_name="efitrt1")
+            params.data_conn.get_data(r"\efit_a_eqdsk:atime", tree_name="efitrt1")
             / 1.0e3
         )  # [ms] -> [s]
         # EFIT reconstructions are sometimes invalid, particularly when very close

--- a/disruption_py/machine/d3d/physics.py
+++ b/disruption_py/machine/d3d/physics.py
@@ -64,7 +64,7 @@ class D3DPhysicsMethods:
         Parameters
         ----------
         params : PhysicsMethodParams
-            Parameters containing MDS connection and shot information.
+            Parameters containing data connection and shot information.
 
         Returns
         -------
@@ -81,7 +81,7 @@ class D3DPhysicsMethods:
             "h98": [np.nan],
         }
         try:
-            h_98, t_h_98 = params.mds_conn.get_data_with_dims(
+            h_98, t_h_98 = params.data_conn.get_data_with_dims(
                 r"\H_THH98Y2", tree_name="transport"
             )
             t_h_98 /= 1e3  # [ms] -> [s]
@@ -101,7 +101,7 @@ class D3DPhysicsMethods:
         Parameters
         ----------
         params : PhysicsMethodParams
-            Parameters containing MDS connection and shot information.
+            Parameters containing data connection and shot information.
 
         Returns
         -------
@@ -119,7 +119,7 @@ class D3DPhysicsMethods:
             "h_alpha": [np.nan],
         }
         try:
-            h_alpha, t_h_alpha = params.mds_conn.get_data_with_dims(
+            h_alpha, t_h_alpha = params.data_conn.get_data_with_dims(
                 r"\fs04", tree_name="d3d"
             )
             t_h_alpha /= 1e3  # [ms] -> [s]
@@ -149,7 +149,7 @@ class D3DPhysicsMethods:
         Parameters
         ----------
         params : PhysicsMethodParams
-            The parameters containing the MDSplus connection, shot id and more.
+            The parameters containing the data connection, shot id and more.
 
         Returns
         -------
@@ -166,7 +166,7 @@ class D3DPhysicsMethods:
         """
         # Get neutral beam injected power
         try:
-            p_nbi, t_nbi = params.mds_conn.get_data_with_dims(
+            p_nbi, t_nbi = params.data_conn.get_data_with_dims(
                 r"\top.nb:pinj", tree_name="d3d"
             )
             t_nbi /= 1e3  # [ms] -> [s]
@@ -191,7 +191,7 @@ class D3DPhysicsMethods:
         # Get electron cyclotron heating (ECH) power. It's point data, so it's not
         # stored in an MDSplus tree
         try:
-            p_ech, t_ech = params.mds_conn.get_data_with_dims(
+            p_ech, t_ech = params.data_conn.get_data_with_dims(
                 r"\top.ech.total:echpwrc", tree_name="rf"
             )
             t_ech /= 1e3  # [ms] -> [s]
@@ -234,7 +234,7 @@ class D3DPhysicsMethods:
         smoothing_window = 0.010  # [s]
 
         try:
-            bol_prm, _ = params.mds_conn.get_data_with_dims(
+            bol_prm, _ = params.data_conn.get_data_with_dims(
                 r"\bol_prm", tree_name="bolom"
             )
         except mdsExceptions.MdsException as e:
@@ -245,11 +245,11 @@ class D3DPhysicsMethods:
         bol_channels = upper_channels + lower_channels
         bol_signals = []
         for i in range(48):
-            bol_signal = params.mds_conn.get_data(
+            bol_signal = params.data_conn.get_data(
                 rf"\top.raw:{bol_channels[i]}", tree_name="bolom"
             )
             bol_signals.append(bol_signal)
-        bol_time = params.mds_conn.get_dims(
+        bol_time = params.data_conn.get_dims(
             rf"\top.raw:{bol_channels[0]}", tree_name="bolom"
         )[0]
         bol_time /= 1e3  # [ms] -> [s]
@@ -304,7 +304,7 @@ class D3DPhysicsMethods:
         Parameters
         ----------
         params : PhysicsMethodParams
-            The parameters containing the MDSplus connection, shot id and more.
+            The parameters containing the data connection, shot id and more.
 
         Returns
         -------
@@ -320,14 +320,16 @@ class D3DPhysicsMethods:
         - issues: #[229](https://github.com/MIT-PSFC/disruption-py/issues/229)
         """
         # Get edge loop voltage and smooth it a bit with a median filter
-        v_loop, t_v_loop = params.mds_conn.get_data_with_dims(
+        v_loop, t_v_loop = params.data_conn.get_data_with_dims(
             f'ptdata("vloopb", {params.shot_id})'
         )
         t_v_loop /= 1e3  # [ms] -> [s]
         v_loop = scipy.signal.medfilt(v_loop, 11)
         v_loop = interp1(t_v_loop, v_loop, params.times, "linear")
         # Get plasma current
-        ip, t_ip = params.mds_conn.get_data_with_dims(f"ptdata('ip', {params.shot_id})")
+        ip, t_ip = params.data_conn.get_data_with_dims(
+            f"ptdata('ip', {params.shot_id})"
+        )
         t_ip /= 1e3  # [ms] -> [s]
 
         # Alessandro Pau (JET & AUG) has given Cristina a robust routine that
@@ -347,17 +349,19 @@ class D3DPhysicsMethods:
             ends_type=1,
             slew_rate=0,
         )
-        li, t_li = params.mds_conn.get_data_with_dims(
+        li, t_li = params.data_conn.get_data_with_dims(
             r"\efit_a_eqdsk:li", tree_name="_efit_tree"
         )
         t_li /= 1e3
         # Use chisq to determine which time slices are invalid
-        chisq = params.mds_conn.get_data(r"\efit_a_eqdsk:chisq", tree_name="_efit_tree")
+        chisq = params.data_conn.get_data(
+            r"\efit_a_eqdsk:chisq", tree_name="_efit_tree"
+        )
         # Filter out invalid indices of efit reconstruction
         (invalid_indices,) = np.where(chisq > 50)
         li[invalid_indices] = np.nan
 
-        r_0, t_r0 = params.mds_conn.get_data_with_dims(
+        r_0, t_r0 = params.data_conn.get_data_with_dims(
             r"\top.results.geqdsk:rmaxis", tree_name="_efit_tree"
         )  # [m], [ms]
         t_r0 /= 1e3  # [ms] -> [s]
@@ -391,7 +395,7 @@ class D3DPhysicsMethods:
         Parameters
         ----------
         params : PhysicsMethodParams
-            The parameters containing the MDSplus connection, shot id and more.
+            The parameters containing the data connection, shot id and more.
 
         Returns
         -------
@@ -406,7 +410,7 @@ class D3DPhysicsMethods:
         - pull requests: #[249](https://github.com/MIT-PSFC/disruption-py/pull/249)
         """
         try:
-            ne, t_ne = params.mds_conn.get_data_with_dims(
+            ne, t_ne = params.data_conn.get_data_with_dims(
                 r"\density", tree_name="_efit_tree"
             )
         except mdsExceptions.MdsException:
@@ -421,8 +425,8 @@ class D3DPhysicsMethods:
         #  - r"\efit01:density" gives ne = array([4.06199e19]), t_ne = array([1800])
         #  - "\d3d:denv2" gives actual density data
         if not np.isfinite(ne).any() or len(ne) < 2:
-            ne, t_ne = params.mds_conn.get_data_with_dims(r"\denv2", tree_name="d3d")
-            tree_name = params.mds_conn.get_tree_name_of_nickname("_efit_tree")
+            ne, t_ne = params.data_conn.get_data_with_dims(r"\denv2", tree_name="d3d")
+            tree_name = params.data_conn.get_tree_name_of_nickname("_efit_tree")
             params.logger.verbose(
                 rf"density: data from \{tree_name}:density is either empty or invalid."
                 r" Use \d3d:denv2 instead."
@@ -447,13 +451,13 @@ class D3DPhysicsMethods:
             bounds_error=False,
         )
         try:
-            ip, t_ip = params.mds_conn.get_data_with_dims(
+            ip, t_ip = params.data_conn.get_data_with_dims(
                 f"ptdata('ip', {params.shot_id})"
             )  # [A], [ms]
             t_ip = t_ip / 1.0e3  # [ms] -> [s]
             ipsign = np.sign(np.sum(ip))
             ip = interp1(t_ip, ip * ipsign, params.times, "linear")  # positive definite
-            a_minor, t_a = params.mds_conn.get_data_with_dims(
+            a_minor, t_a = params.data_conn.get_data_with_dims(
                 r"\efit_a_eqdsk:aminor", tree_name="_efit_tree"
             )  # [m], [ms]
             t_a = t_a / 1.0e3  # [ms] -> [s]
@@ -495,7 +499,7 @@ class D3DPhysicsMethods:
         Parameters
         ----------
         params : PhysicsMethodParams
-            The parameters containing the MDSplus connection, shot id and more.
+            The parameters containing the data connection, shot id and more.
 
         Returns
         -------
@@ -510,7 +514,7 @@ class D3DPhysicsMethods:
         /disruption-py/blob/matlab/DIII-D/get_density_parameters_RT.m)
         - pull requests: #[251](https://github.com/MIT-PSFC/disruption-py/pull/251)
         """
-        ne_rt, t_ne_rt = params.mds_conn.get_data_with_dims(
+        ne_rt, t_ne_rt = params.data_conn.get_data_with_dims(
             f"ptdata('dssdenest', {params.shot_id})"
         )  # [10^19 m^-3]
         t_ne_rt = t_ne_rt / 1.0e3  # [ms] to [s]
@@ -522,12 +526,12 @@ class D3DPhysicsMethods:
         # Get real time ip to calculate the Greenwald density
 
         try:
-            ip_rt, t_ip_rt = params.mds_conn.get_data_with_dims(
+            ip_rt, t_ip_rt = params.data_conn.get_data_with_dims(
                 f"ptdata('ipsip', {params.shot_id})"
             )  # [MA], [ms]
             t_ip_rt = t_ip_rt / 1.0e3  # [ms] to [s]
         except mdsExceptions.MdsException:
-            ip_rt, t_ip_rt = params.mds_conn.get_data_with_dims(
+            ip_rt, t_ip_rt = params.data_conn.get_data_with_dims(
                 f"ptdata('ipspr15v', {params.shot_id})"
             )  # [volts; 2 V/MA], [ms]
             t_ip_rt = t_ip_rt / 1.0e3  # [ms] to [s]
@@ -544,7 +548,7 @@ class D3DPhysicsMethods:
 
         # For the real-time (RT) signals, read from the EFITRT1 tree
         try:
-            a_minor_rt, t_a_rt = params.mds_conn.get_data_with_dims(
+            a_minor_rt, t_a_rt = params.data_conn.get_data_with_dims(
                 r"\efit_a_eqdsk:aminor", tree_name="efitrt1"
             )  # [m], [ms]
             t_a_rt = t_a_rt / 1.0e3  # [ms] -> [s]
@@ -588,7 +592,7 @@ class D3DPhysicsMethods:
         Parameters
         ----------
         params : PhysicsMethodParams
-            Parameters containing MDS connection and shot information
+            Parameters containing data connection and shot information
 
         Returns
         -------
@@ -615,7 +619,7 @@ class D3DPhysicsMethods:
         ip_error = np.full(len(params.times), np.nan)
         # Get measured plasma current parameters
         try:
-            ip, t_ip = params.mds_conn.get_data_with_dims(
+            ip, t_ip = params.data_conn.get_data_with_dims(
                 f"ptdata('ip', {params.shot_id})"
             )  # [A], [ms]
             t_ip = t_ip / 1.0e3  # [ms] -> [s]
@@ -627,7 +631,7 @@ class D3DPhysicsMethods:
             params.logger.opt(exception=True).debug(e)
         # Get programmed plasma current parameters
         try:
-            ip_prog, t_ip_prog = params.mds_conn.get_data_with_dims(
+            ip_prog, t_ip_prog = params.data_conn.get_data_with_dims(
                 f"ptdata('iptipp', {params.shot_id})"
             )  # [A], [ms]
             t_ip_prog = t_ip_prog / 1.0e3  # [ms] -> [s]
@@ -649,7 +653,7 @@ class D3DPhysicsMethods:
         #  Anything else: not in normal Ip feedback mode.  In this case, the
         # 'ip_prog' signal is irrelevant, and therefore 'ip_error' is not defined.
         try:
-            ipimode, t_ipimode = params.mds_conn.get_data_with_dims(
+            ipimode, t_ipimode = params.data_conn.get_data_with_dims(
                 f"ptdata('ipimode', {params.shot_id})"
             )
             t_ipimode = t_ipimode / 1.0e3  # [ms] -> [s]
@@ -672,7 +676,7 @@ class D3DPhysicsMethods:
         # PCS feedback control of Ip is not being applied.  Therefore the
         # 'ip_error' parameter is undefined for these times.
         try:
-            epsoff, t_epsoff = params.mds_conn.get_data_with_dims(
+            epsoff, t_epsoff = params.data_conn.get_data_with_dims(
                 f"ptdata('epsoff', {params.shot_id})"
             )
             t_epsoff = t_epsoff / 1.0e3  # [ms] -> [s]
@@ -716,7 +720,7 @@ class D3DPhysicsMethods:
         Parameters
         ----------
         params : PhysicsMethodParams
-            Parameters containing MDS connection and shot information
+            Parameters containing data connection and shot information
 
         Returns
         -------
@@ -739,7 +743,7 @@ class D3DPhysicsMethods:
         # Get measured plasma current parameters
         # TODO: Why open d3d and not the rt efit tree?
         try:
-            ip_rt, t_ip_rt = params.mds_conn.get_data_with_dims(
+            ip_rt, t_ip_rt = params.data_conn.get_data_with_dims(
                 f"ptdata('ipsip', {params.shot_id})"
             )  # [MA], [ms]
             t_ip_rt = t_ip_rt / 1.0e3  # [ms] -> [s]
@@ -754,7 +758,7 @@ class D3DPhysicsMethods:
             params.logger.opt(exception=True).debug(e)
         # Get programmed plasma current parameters
         try:
-            ip_prog_rt, t_ip_prog_rt = params.mds_conn.get_data_with_dims(
+            ip_prog_rt, t_ip_prog_rt = params.data_conn.get_data_with_dims(
                 f"ptdata('ipsiptargt', {params.shot_id})"
             )  # [MA], [ms]
             t_ip_prog_rt = t_ip_prog_rt / 1.0e3  # [ms] -> [s]
@@ -770,7 +774,7 @@ class D3DPhysicsMethods:
             )
             params.logger.opt(exception=True).debug(e)
         try:
-            ip_error_rt, t_ip_error_rt = params.mds_conn.get_data_with_dims(
+            ip_error_rt, t_ip_error_rt = params.data_conn.get_data_with_dims(
                 f"ptdata('ipeecoil', {params.shot_id})"
             )  # [MA], [ms]
             t_ip_error_rt = t_ip_error_rt / 1.0e3  # [ms] to [s]
@@ -791,7 +795,7 @@ class D3DPhysicsMethods:
         #  Anything else: not in normal Ip feedback mode.  In this case, the
         # 'ip_prog' signal is irrelevant, and therefore 'ip_error' is not defined.
         try:
-            ipimode, t_ipimode = params.mds_conn.get_data_with_dims(
+            ipimode, t_ipimode = params.data_conn.get_data_with_dims(
                 f"ptdata('ipimode', {params.shot_id})"
             )
             t_ipimode = t_ipimode / 1.0e3  # [ms] -> [s]
@@ -810,7 +814,7 @@ class D3DPhysicsMethods:
         # PCS feedback control of Ip is not being applied.  Therefore the
         # 'ip_error' parameter is undefined for these times.
         try:
-            epsoff, t_epsoff = params.mds_conn.get_data_with_dims(
+            epsoff, t_epsoff = params.data_conn.get_data_with_dims(
                 f"ptdata('epsoff', {params.shot_id})"
             )
             t_epsoff = t_epsoff / 1.0e3  # [ms] -> [s]
@@ -858,7 +862,7 @@ class D3DPhysicsMethods:
         Parameters
         ----------
         params : PhysicsMethodParams
-            Parameters containing MDS connection and shot information
+            Parameters containing data connection and shot information
 
         Returns
         -------
@@ -873,7 +877,7 @@ class D3DPhysicsMethods:
         """
         nominal_flattop_radius = 0.59
         # Get z_cur
-        z_cur, t_z_cur = params.mds_conn.get_data_with_dims(
+        z_cur, t_z_cur = params.data_conn.get_data_with_dims(
             f"ptdata('vpszp', {params.shot_id})"
         )
         t_z_cur = t_z_cur / 1.0e3  # [ms] -> [s]
@@ -881,11 +885,11 @@ class D3DPhysicsMethods:
         z_cur = interp1(t_z_cur, z_cur, params.times, "linear")
         # Compute z_cur_norm
         try:
-            a_minor, t_a = params.mds_conn.get_data_with_dims(
+            a_minor, t_a = params.data_conn.get_data_with_dims(
                 r"\efit_a_eqdsk:aminor", tree_name="_efit_tree"
             )  # [m], [ms]
             t_a = t_a / 1.0e3  # [ms] -> [s]
-            chisq = params.mds_conn.get_data(
+            chisq = params.data_conn.get_data(
                 r"\efit_a_eqdsk:chisq", tree_name="_efit_tree"
             )
             (invalid_indices,) = np.where(chisq > 50)
@@ -908,7 +912,7 @@ class D3DPhysicsMethods:
         Parameters
         ----------
         params : PhysicsMethodParams
-            The parameters containing the MDSplus connection, shot id and more.
+            The parameters containing the data connection, shot id and more.
 
         Returns
         -------
@@ -922,13 +926,13 @@ class D3DPhysicsMethods:
         - pull requests: #[257](https://github.com/MIT-PSFC/disruption-py/pull/257)
         """
         # Get n1rms signal from d3d tree
-        n1rms, t_n1rms = params.mds_conn.get_data_with_dims(r"\n1rms", tree_name="d3d")
+        n1rms, t_n1rms = params.data_conn.get_data_with_dims(r"\n1rms", tree_name="d3d")
         n1rms *= 1.0e-4  # Gauss -> Tesla
         t_n1rms /= 1e3  # [ms] -> [s]
         n1rms = interp1(t_n1rms, n1rms, params.times)
         # Calculate n1rms_norm
         try:
-            b_tor, t_b_tor = params.mds_conn.get_data_with_dims(
+            b_tor, t_b_tor = params.data_conn.get_data_with_dims(
                 f"ptdata('bt', {params.shot_id})"
             )
             t_b_tor /= 1e3  # [ms] -> [s]
@@ -1033,12 +1037,12 @@ class D3DPhysicsMethods:
         # Get precomputed rad_cva & rad_xdiv data stored in ptdata tree
         calculate_prad_pf = False
         try:
-            rad_cva, t_rad_cva = params.mds_conn.get_data_with_dims(
+            rad_cva, t_rad_cva = params.data_conn.get_data_with_dims(
                 f"ptdata('dpsrrdcva', {params.shot_id})"
             )  # [], [ms]
             t_rad_cva /= 1e3  # [ms] -> [s]
             rad_cva = interp1(t_rad_cva, rad_cva, params.times)
-            rad_xdiv, t_rad_xdiv = params.mds_conn.get_data_with_dims(
+            rad_xdiv, t_rad_xdiv = params.data_conn.get_data_with_dims(
                 f"ptdata('dpsrrdxdiv', {params.shot_id})"
             )  # [], [ms]
             t_rad_xdiv /= 1e3  # [ms] -> [s]
@@ -1268,7 +1272,7 @@ class D3DPhysicsMethods:
         Parameters
         ----------
         params : PhysicsMethodParams
-            Parameters containing MDS connection and shot information
+            Parameters containing data connection and shot information
 
         Returns
         -------
@@ -1276,7 +1280,7 @@ class D3DPhysicsMethods:
             A dictionary containing `z_eff`
         """
         # Get Zeff
-        zeff, t_zeff = params.mds_conn.get_data_with_dims(
+        zeff, t_zeff = params.data_conn.get_data_with_dims(
             r"\top.spectroscopy.vb.zeff:zeff", tree_name="d3d"
         )
         t_zeff = t_zeff / 1.0e3  # [ms] -> [s]
@@ -1310,7 +1314,7 @@ class D3DPhysicsMethods:
         Parameters
         ----------
         params : PhysicsMethodParams
-            The parameters containing the MDSplus connection, shot id and more.
+            The parameters containing the data connection, shot id and more.
 
         Returns
         -------
@@ -1323,12 +1327,14 @@ class D3DPhysicsMethods:
         /blob/matlab/DIII-D/get_kappa_area.m)
         - pull requests: #[256](https://github.com/MIT-PSFC/disruption-py/pull/256)
         """
-        a_minor = params.mds_conn.get_data(
+        a_minor = params.data_conn.get_data(
             r"\efit_a_eqdsk:aminor", tree_name="_efit_tree"
         )
-        area = params.mds_conn.get_data(r"\efit_a_eqdsk:area", tree_name="_efit_tree")
-        chisq = params.mds_conn.get_data(r"\efit_a_eqdsk:chisq", tree_name="_efit_tree")
-        t = params.mds_conn.get_data(r"\efit_a_eqdsk:atime", tree_name="_efit_tree")
+        area = params.data_conn.get_data(r"\efit_a_eqdsk:area", tree_name="_efit_tree")
+        chisq = params.data_conn.get_data(
+            r"\efit_a_eqdsk:chisq", tree_name="_efit_tree"
+        )
+        t = params.data_conn.get_data(r"\efit_a_eqdsk:atime", tree_name="_efit_tree")
         t /= 1e3  # [ms] -> [s]
         kappa_area = area / (np.pi * a_minor**2)
         invalid_indices = np.where(chisq > 50)
@@ -1349,7 +1355,7 @@ class D3DPhysicsMethods:
         Parameters
         ----------
         params : PhysicsMethodParams
-            The parameters containing the MDSplus connection, shot id and more.
+            The parameters containing the data connection, shot id and more.
 
         Returns
         -------
@@ -1363,16 +1369,16 @@ class D3DPhysicsMethods:
         - pull requests: #[258](https://github.com/MIT-PSFC/disruption-py/pull/258)
         """
         # Get efit_time
-        efit_time = params.mds_conn.get_data(
+        efit_time = params.data_conn.get_data(
             r"\efit_a_eqdsk:atime", tree_name="_efit_tree"
         )
         efit_time /= 1e3  # [ms] -> [s]
         # Compute triangularity
         try:
-            tritop = params.mds_conn.get_data(
+            tritop = params.data_conn.get_data(
                 r"\efit_a_eqdsk:tritop", tree_name="_efit_tree"
             )  # meters
-            tribot = params.mds_conn.get_data(
+            tribot = params.data_conn.get_data(
                 r"\efit_a_eqdsk:tribot", tree_name="_efit_tree"
             )  # meters
             delta = (tritop + tribot) / 2.0
@@ -1382,10 +1388,10 @@ class D3DPhysicsMethods:
             delta = None
         # Compute squareness
         try:
-            sqfod = params.mds_conn.get_data(
+            sqfod = params.data_conn.get_data(
                 r"\efit_a_eqdsk:sqfod", tree_name="_efit_tree"
             )
-            sqfou = params.mds_conn.get_data(
+            sqfou = params.data_conn.get_data(
                 r"\efit_a_eqdsk:sqfou", tree_name="_efit_tree"
             )
             squareness = (sqfod + sqfou) / 2.0
@@ -1395,7 +1401,7 @@ class D3DPhysicsMethods:
             squareness = None
         # Get aminor
         try:
-            aminor = params.mds_conn.get_data(
+            aminor = params.data_conn.get_data(
                 r"\efit_a_eqdsk:aminor", tree_name="_efit_tree"
             )
         except mdsExceptions.MdsException as e:
@@ -1404,7 +1410,7 @@ class D3DPhysicsMethods:
             aminor = None
         # Check chisq for invalid indices
         try:
-            chisq = params.mds_conn.get_data(
+            chisq = params.data_conn.get_data(
                 r"\efit_a_eqdsk:chisq", tree_name="_efit_tree"
             )
             invalid_indices = np.where(chisq > 50)
@@ -1487,7 +1493,7 @@ class D3DPhysicsMethods:
             lasers[laser] = {}
             sub_tree = f"{mds_path}{laser}"
             try:
-                (t_sub_tree,) = params.mds_conn.get_dims(
+                (t_sub_tree,) = params.data_conn.get_dims(
                     f"{sub_tree}:temp", tree_name="electrons"
                 )
                 # lasers[laser]['time'] gets overwritten in the loop later
@@ -1511,7 +1517,7 @@ class D3DPhysicsMethods:
             }
             for node, name in child_nodes.items():
                 try:
-                    lasers[laser][node] = params.mds_conn.get_data(
+                    lasers[laser][node] = params.data_conn.get_data(
                         f"{sub_tree}:{name}", tree_name="electrons"
                     )
                 except mdsExceptions.MdsException as e:
@@ -1588,7 +1594,7 @@ class D3DPhysicsMethods:
             return False
 
         # Get bolometry data
-        bol_prm, _ = params.mds_conn.get_data_with_dims(r"\bol_prm", tree_name="bolom")
+        bol_prm, _ = params.data_conn.get_data_with_dims(r"\bol_prm", tree_name="bolom")
         upper_channels = [f"bol_u{i+1:02d}_v" for i in range(24)]
         lower_channels = [f"bol_l{i+1:02d}_v" for i in range(24)]
         bol_channels = upper_channels + lower_channels
@@ -1597,7 +1603,7 @@ class D3DPhysicsMethods:
             []
         )  # TODO: Decide whether to actually use all bol_times instead of just first one
         for i in range(48):
-            bol_signal, bol_time = params.mds_conn.get_data_with_dims(
+            bol_signal, bol_time = params.data_conn.get_data_with_dims(
                 rf"\top.raw:{bol_channels[i]}", tree_name="bolom"
             )
             bol_time /= 1e3  # [ms] -> [s]
@@ -1612,7 +1618,7 @@ class D3DPhysicsMethods:
             smoothing_window,
         )
         b_struct = matlab_power(a_struct)
-        r_major_axis, efit_time = params.mds_conn.get_data_with_dims(
+        r_major_axis, efit_time = params.data_conn.get_data_with_dims(
             r"\top.results.geqdsk:rmaxis", tree_name="_efit_tree"
         )
         efit_time /= 1e3  # [ms] -> [s]
@@ -1676,7 +1682,7 @@ class D3DPhysicsMethods:
         Parameters
         ----------
         params : PhysicsMethodParams
-            Parameters containing MDS connection and shot information
+            Parameters containing data connection and shot information
 
         Returns
         -------
@@ -1703,13 +1709,13 @@ class D3DPhysicsMethods:
         """
         path = r"\top.results.geqdsk:"
         nodes = ["z", "r", "rhovn", "psirz", "zmaxis", "ssimag", "ssibry"]
-        (efit_dict_time,) = params.mds_conn.get_dims(
+        (efit_dict_time,) = params.data_conn.get_dims(
             f"{path}psirz", tree_name="_efit_tree", dim_nums=[2]
         )
         efit_dict = {"time": efit_dict_time / 1e3}  # [ms] -> [s]
         for node in nodes:
             try:
-                efit_dict[node] = params.mds_conn.get_data(
+                efit_dict[node] = params.data_conn.get_data(
                     f"{path}{node}", tree_name="_efit_tree"
                 )
             except mdsExceptions.MdsException as e:

--- a/disruption_py/machine/d3d/util.py
+++ b/disruption_py/machine/d3d/util.py
@@ -19,21 +19,21 @@ class D3DUtilMethods:
     def get_polarity(params: PhysicsMethodParams):
         """
         Get the plasma current polarity. Accepts PhysicsMethodParams to access
-        the MDS connection, but it is not a physics method.
+        the data connection, but it is not a physics method.
 
         Returns the first value of polarity array if the polarity is not constant.
 
         Parameters
         ----------
         params : PhysicsMethodParams
-            Parameters containing MDS connection and shot information.
+            Parameters containing data connection and shot information.
 
         Returns
         -------
         polarity value, -1 or 1.
         """
         polarity = np.unique(
-            params.mds_conn.get_data(f"ptdata('iptdirect', {params.shot_id})")
+            params.data_conn.get_data(f"ptdata('iptdirect', {params.shot_id})")
         )
         if len(polarity) > 1:
             params.logger.info(

--- a/disruption_py/machine/east/efit.py
+++ b/disruption_py/machine/east/efit.py
@@ -65,7 +65,7 @@ class EastEfitMethods:
         Parameters
         ----------
         params : PhysicsMethodParams
-            The parameters containing the MDS connection and shot information.
+            The parameters containing the data connection and shot information.
 
         Returns
         -------
@@ -75,10 +75,10 @@ class EastEfitMethods:
         # pylint: disable=duplicate-code
 
         efit_data = {
-            k: params.mds_conn.get_data(v, tree_name="_efit_tree")
+            k: params.data_conn.get_data(v, tree_name="_efit_tree")
             for k, v in EastEfitMethods.efit_cols.items()
         }
-        efit_time = params.mds_conn.get_data(
+        efit_time = params.data_conn.get_data(
             r"\efit_aeqdsk:atime", tree_name="_efit_tree"
         )  # TODO: [unit?]
 
@@ -113,7 +113,7 @@ class EastEfitMethods:
         Parameters
         ----------
         params : PhysicsMethodParams
-            The parameters containing the MDS connection and shot information.
+            The parameters containing the data connection and shot information.
 
         Returns
         -------
@@ -122,7 +122,7 @@ class EastEfitMethods:
         """
         # pylint: disable=duplicate-code
 
-        efit_time = params.mds_conn.get_data(
+        efit_time = params.data_conn.get_data(
             r"\efit_a_eqdsk:atime", tree_name="pefit_east"
         )  # TODO: [unit?]
 
@@ -130,7 +130,7 @@ class EastEfitMethods:
         efit_time, unique_indices = np.unique(efit_time, return_index=True)
 
         efit_data = {
-            k: params.mds_conn.get_data(v, tree_name="pefit_east")[unique_indices]
+            k: params.data_conn.get_data(v, tree_name="pefit_east")[unique_indices]
             for k, v in EastEfitMethods.pefit_cols.items()
         }
 

--- a/disruption_py/machine/east/physics.py
+++ b/disruption_py/machine/east/physics.py
@@ -70,7 +70,7 @@ class EastPhysicsMethods:
         Parameters
         ----------
         params : PhysicsMethodParams
-            Parameters containing MDS connection and shot information
+            Parameters containing data connection and shot information
 
         Returns
         -------
@@ -96,7 +96,7 @@ class EastPhysicsMethods:
         dip_dt = [np.nan]
         dipprog_dt = [np.nan]
 
-        ip, ip_time = EastUtilMethods.retrieve_ip(params.mds_conn, params.shot_id)
+        ip, ip_time = EastUtilMethods.retrieve_ip(params.data_conn, params.shot_id)
         # Calculate dip_dt
         dip_dt = np.gradient(ip, ip_time)
 
@@ -115,12 +115,12 @@ class EastPhysicsMethods:
 
         # Start with \lmtipref (standard Ip programming), which is defined for the
         # entire shot, and defines the timebase for the programmed Ip signal.
-        ip_prog, ip_prog_time = params.mds_conn.get_data_with_dims(
+        ip_prog, ip_prog_time = params.data_conn.get_data_with_dims(
             r"\lmtipref*1e6", tree_name="pcs_east"
         )  # [A], [s]
 
         # Now check to see if there is a transition to isoflux control
-        sytps1, time_sytps1 = params.mds_conn.get_data_with_dims(
+        sytps1, time_sytps1 = params.data_conn.get_data_with_dims(
             r"\sytps1", tree_name="pcs_east"
         )
         (sytps1_indices,) = np.where(sytps1 > 0)
@@ -131,7 +131,7 @@ class EastPhysicsMethods:
 
         if len(sytps1_indices) > 0 and time_sytps1[0] <= ip_prog_time[-1]:
             try:
-                ietip, ietip_time = params.mds_conn.get_data_with_dims(
+                ietip, ietip_time = params.data_conn.get_data_with_dims(
                     r"\ietip", tree_name="pcs_east"
                 )
                 ietip = interp1(ietip_time, ietip, ip_prog_time)
@@ -139,7 +139,7 @@ class EastPhysicsMethods:
                 ietip = np.full(len(ip_prog_time), np.nan)
 
             try:
-                idtip, idtip_time = params.mds_conn.get_data_with_dims(
+                idtip, idtip_time = params.data_conn.get_data_with_dims(
                     r"\idtip", tree_name="pcs_east"
                 )
                 idtip = interp1(idtip_time, idtip, ip_prog_time)
@@ -147,7 +147,7 @@ class EastPhysicsMethods:
                 idtip = np.full(len(ip_prog_time), np.nan)
 
             try:
-                istip, istip_time = params.mds_conn.get_data_with_dims(
+                istip, istip_time = params.data_conn.get_data_with_dims(
                     r"\istip", tree_name="pcs_east"
                 )
                 istip = interp1(istip_time, istip, ip_prog_time)
@@ -155,7 +155,7 @@ class EastPhysicsMethods:
                 istip = np.full(len(ip_prog_time), np.nan)
 
             try:
-                iutip, iutip_time = params.mds_conn.get_data_with_dims(
+                iutip, iutip_time = params.data_conn.get_data_with_dims(
                     r"\iutip", tree_name="pcs_east"
                 )
                 iutip = interp1(iutip_time, iutip, ip_prog_time)
@@ -222,7 +222,7 @@ class EastPhysicsMethods:
         Parameters
         ----------
         params : PhysicsMethodParams
-            Parameters containing MDS connection and shot information
+            Parameters containing data connection and shot information
 
         Returns
         -------
@@ -241,14 +241,14 @@ class EastPhysicsMethods:
         # Get "\vp1_s" signal from the EAST tree.  (This signal is a sub-sampled
         # version of "vp1".)
         try:
-            v_loop, v_loop_time = params.mds_conn.get_data_with_dims(
+            v_loop, v_loop_time = params.data_conn.get_data_with_dims(
                 r"\vp1_s", tree_name="east"
             )
         except mdsExceptions.MdsException:
             params.logger.verbose(
                 r"v_loop: Failed to get \vp1_s data. Use \pcvloop from pcs_east instead."
             )
-            v_loop, v_loop_time = params.mds_conn.get_data_with_dims(
+            v_loop, v_loop_time = params.data_conn.get_data_with_dims(
                 r"\pcvloop", tree_name="pcs_east"
             )  # [V]
 
@@ -284,7 +284,7 @@ class EastPhysicsMethods:
         Parameters
         ----------
         params : PhysicsMethodParams
-            Parameters containing MDS connection and shot information
+            Parameters containing data connection and shot information
 
         Returns
         -------
@@ -300,7 +300,7 @@ class EastPhysicsMethods:
         blob/matlab/EAST/get_Z_error.m)
         """
         # Read in the calculated zcur from EFIT
-        zcur, zcur_time = params.mds_conn.get_data_with_dims(
+        zcur, zcur_time = params.data_conn.get_data_with_dims(
             r"\efit_aeqdsk:zcur", tree_name="_efit_tree"
         )  # [A], [s]
         # Deal with rare bug
@@ -309,15 +309,15 @@ class EastPhysicsMethods:
 
         # Read in aminor from EFIT
         # TODO: use \aminor or \aout? -- MATLAB: \aminor
-        aminor = params.mds_conn.get_data(r"\aminor", tree_name="_efit_tree")  # [m]
+        aminor = params.data_conn.get_data(r"\aminor", tree_name="_efit_tree")  # [m]
         aminor = aminor[unique_indices]
 
         # Next, get the programmed/requested/target Z from PCS, and the
         # calculated Z-centroid from PCS
-        z_prog, z_prog_time = params.mds_conn.get_data_with_dims(
+        z_prog, z_prog_time = params.data_conn.get_data_with_dims(
             r"\lmtzref/100", tree_name="pcs_east"
         )  # [m], [s] (Node says 'm' but it's wrong)
-        zcur_lmsz, lmsz_time = params.mds_conn.get_data_with_dims(
+        zcur_lmsz, lmsz_time = params.data_conn.get_data_with_dims(
             r"\lmsz", tree_name="pcs_east"
         )  # [m], [s]
 
@@ -371,7 +371,7 @@ class EastPhysicsMethods:
         Parameters
         ----------
         params : PhysicsMethodParams
-            Parameters containing MDS connection and shot information
+            Parameters containing data connection and shot information
 
         Returns
         -------
@@ -389,7 +389,7 @@ class EastPhysicsMethods:
         dn_dt = [np.nan]
 
         # Get the density and calculate dn_dt
-        ne, netime = params.mds_conn.get_data_with_dims(
+        ne, netime = params.data_conn.get_data_with_dims(
             r"\dfsdev*1e19", tree_name="pcs_east"
         )  # [m^-3], [s]
         dn_dt = np.gradient(ne, netime)  # [m^-3/s]
@@ -400,7 +400,7 @@ class EastPhysicsMethods:
 
         # Calculate Greenwald density
         # TODO: use \aminor or \aout? -- MATLAB: \aout
-        aminor, efittime = params.mds_conn.get_data_with_dims(
+        aminor, efittime = params.data_conn.get_data_with_dims(
             r"\efit_aeqdsk:aout", tree_name="_efit_tree"
         )  # [m], [s]
         aminor = interp1(efittime, aminor, params.times)
@@ -423,7 +423,7 @@ class EastPhysicsMethods:
         these functions different.
         """
         # Get XUV data
-        (xuvtime,) = params.mds_conn.get_dims(r"\pxuv1", tree_name="east_1")  # [s]
+        (xuvtime,) = params.data_conn.get_dims(r"\pxuv1", tree_name="east_1")  # [s]
         # There are 64 AXUV chords, arranged in 4 arrays of 16 channels each
         xuv = np.full((len(xuvtime), 64), np.nan)
 
@@ -434,7 +434,7 @@ class EastPhysicsMethods:
         for iarray in range(4):
             for ichan in range(16):
                 ichord = 16 * iarray + ichan
-                signal = params.mds_conn.get_data(
+                signal = params.data_conn.get_data(
                     r"\pxuv" + str(ichord + 1), tree_name="east_1"
                 )
                 # Subtract baseline
@@ -455,7 +455,7 @@ class EastPhysicsMethods:
         Parameters
         ----------
         params : PhysicsMethodParams
-            Parameters containing MDS connection and shot information
+            Parameters containing data connection and shot information
 
         Returns
         -------
@@ -554,7 +554,7 @@ class EastPhysicsMethods:
         Parameters
         ----------
         params : PhysicsMethodParams
-            Parameters containing MDS connection and shot information
+            Parameters containing data connection and shot information
 
         Returns
         -------
@@ -584,7 +584,7 @@ class EastPhysicsMethods:
             """
             heating_power = np.zeros(params.times.shape)
             for node in nodes:
-                power_node, time_node = params.mds_conn.get_data_with_dims(
+                power_node, time_node = params.data_conn.get_data_with_dims(
                     node, tree_name=tree
                 )
                 heating_power += interp1(
@@ -620,7 +620,7 @@ class EastPhysicsMethods:
 
         # Get ECRH power
         try:
-            p_ecrh, ecrh_time = params.mds_conn.get_data_with_dims(
+            p_ecrh, ecrh_time = params.data_conn.get_data_with_dims(
                 r"\pecrh1i*1e3", tree_name="analysis"
             )  # [W], [s]
             (baseline_indices,) = np.where(ecrh_time < 0)
@@ -681,7 +681,7 @@ class EastPhysicsMethods:
 
         # Get Wmhd, calculate dWmhd_dt, and calculate p_loss
         try:
-            wmhd, efittime = params.mds_conn.get_data_with_dims(
+            wmhd, efittime = params.data_conn.get_data_with_dims(
                 r"\efit_aeqdsk:wmhd", tree_name="_efit_tree"
             )  # [W], [s]
             dwmhd_dt = np.gradient(wmhd, efittime)
@@ -726,7 +726,7 @@ class EastPhysicsMethods:
         Parameters
         ----------
         params : PhysicsMethodParams
-            Parameters containing MDS connection and shot information
+            Parameters containing data connection and shot information
 
         Returns
         -------
@@ -740,14 +740,14 @@ class EastPhysicsMethods:
         """
         # Get raw signals
         try:
-            vloop, vloop_time = params.mds_conn.get_data_with_dims(
+            vloop, vloop_time = params.data_conn.get_data_with_dims(
                 r"\pcvloop", tree_name="pcs_east"
             )  # [V]
-            li, li_time = params.mds_conn.get_data_with_dims(
+            li, li_time = params.data_conn.get_data_with_dims(
                 r"\efit_aeqdsk:li", tree_name="_efit_tree"
             )  # [H]
             # Fetch raw ip signal to calculate dip_dt and apply smoothing
-            ip, ip_time = params.mds_conn.get_data_with_dims(
+            ip, ip_time = params.data_conn.get_data_with_dims(
                 r"\pcrl01", tree_name="pcs_east"
             )  # [A]
         except mdsExceptions.MdsException:
@@ -797,7 +797,7 @@ class EastPhysicsMethods:
         Parameters
         ----------
         params : PhysicsMethodParams
-            Parameters containing MDS connection and shot information
+            Parameters containing data connection and shot information
 
         Returns
         -------
@@ -828,19 +828,19 @@ class EastPhysicsMethods:
 
         # Get the rmp coil currents
         # Translated from get_rmp_and_saddle_signals.m
-        (rmptime,) = params.mds_conn.get_dims(r"\irmpu1", tree_name="east")
+        (rmptime,) = params.data_conn.get_dims(r"\irmpu1", tree_name="east")
         rmp = np.full((len(rmptime), 16), np.nan)
         for i in range(8):
             # Get irmpu1 to irmpu8
-            signal = params.mds_conn.get_data(rf"\irmpu{i+1}", tree_name="east")
+            signal = params.data_conn.get_data(rf"\irmpu{i+1}", tree_name="east")
             if len(signal) == len(rmptime):
                 rmp[:, i] = signal
             # Get irmpl1 to irmpl8
-            signal = params.mds_conn.get_data(rf"\irmpl{i+1}", tree_name="east")
+            signal = params.data_conn.get_data(rf"\irmpl{i+1}", tree_name="east")
             if len(signal) == len(rmptime):
                 rmp[:, i + 8] = signal
         # Get saddle coil signals
-        (saddletime,) = params.mds_conn.get_dims(r"\sad_pa", tree_name="east")
+        (saddletime,) = params.data_conn.get_dims(r"\sad_pa", tree_name="east")
         saddle = np.full((len(saddletime), 8), np.nan)
         saddle_nodes = [
             r"\sad_pa",
@@ -854,11 +854,11 @@ class EastPhysicsMethods:
         ]
         for i, node in enumerate(saddle_nodes[:7]):
             try:
-                saddle[:, i] = params.mds_conn.get_data(node, tree_name="east")
+                saddle[:, i] = params.data_conn.get_data(node, tree_name="east")
             except mdsExceptions.MdsException:
                 saddle[:, i] = 0
-        sad_lo = params.mds_conn.get_data(r"\sad_lo", tree_name="east")
-        sad_lm = params.mds_conn.get_data(r"\sad_lm", tree_name="east")
+        sad_lo = params.data_conn.get_data(r"\sad_lo", tree_name="east")
+        sad_lm = params.data_conn.get_data(r"\sad_lm", tree_name="east")
         saddle[:, 7] = sad_lo - sad_lm
 
         # Calculate RMP n=1 Fourier component amplitude and phase (on the timebase
@@ -921,7 +921,7 @@ class EastPhysicsMethods:
         Parameters
         ----------
         params : PhysicsMethodParams
-            Parameters containing MDS connection and shot information
+            Parameters containing data connection and shot information
 
         Returns
         -------
@@ -940,7 +940,7 @@ class EastPhysicsMethods:
             tree = "pcs_east"
         else:
             tree = "eng_tree"
-        itf, btor_time = params.mds_conn.get_data_with_dims(r"\it", tree_name=tree)
+        itf, btor_time = params.data_conn.get_data_with_dims(r"\it", tree_name=tree)
         btor = (
             (4 * np.pi * 1e-7) * itf * (16 * 130) / (2 * np.pi * 1.8)
         )  # about 4,327 amps/tesla
@@ -972,7 +972,7 @@ class EastPhysicsMethods:
         Parameters
         ----------
         params : PhysicsMethodParams
-            Parameters containing MDS connection and shot information
+            Parameters containing data connection and shot information
 
         Returns
         -------
@@ -1010,7 +1010,7 @@ class EastPhysicsMethods:
         Parameters
         ----------
         params : PhysicsMethodParams
-            Parameters containing MDS connection and shot information
+            Parameters containing data connection and shot information
 
         Returns
         -------
@@ -1046,7 +1046,7 @@ class EastPhysicsMethods:
         Parameters
         ----------
         params : PhysicsMethodParams
-            The parameters containing the MDS connection and shot information.
+            The parameters containing the data connection and shot information.
 
         Returns
         -------
@@ -1069,7 +1069,7 @@ class EastPhysicsMethods:
         }
         for name, node in signals.items():
             try:
-                signal, timearray = params.mds_conn.get_data_with_dims(
+                signal, timearray = params.data_conn.get_data_with_dims(
                     node, tree_name="pcs_east"
                 )
                 signal = interp1(
@@ -1081,7 +1081,7 @@ class EastPhysicsMethods:
 
         # Get q95_rt
         try:
-            q95_rt, q95_rt_time = params.mds_conn.get_data_with_dims(
+            q95_rt, q95_rt_time = params.data_conn.get_data_with_dims(
                 r"\q95", tree_name="pefitrt_east"
             )
             # Deal with bug
@@ -1106,7 +1106,7 @@ class EastPhysicsMethods:
         Parameters
         ----------
         params : PhysicsMethodParams
-            The parameters containing the MDS connection and shot information.
+            The parameters containing the data connection and shot information.
 
         Returns
         -------
@@ -1124,7 +1124,7 @@ class EastPhysicsMethods:
         """
         # Get p_rad_rt
         try:
-            p_rad_rt, timearray = params.mds_conn.get_data_with_dims(
+            p_rad_rt, timearray = params.data_conn.get_data_with_dims(
                 r"\pcprad", tree_name="pcs_east"
             )
             p_rad_rt = interp1(
@@ -1144,7 +1144,7 @@ class EastPhysicsMethods:
         try:
             nbi_signals = {}
             for name, node in nbi_nodes.items():
-                signal, timearray = params.mds_conn.get_data_with_dims(
+                signal, timearray = params.data_conn.get_data_with_dims(
                     node, tree_name="pefitrt_east"
                 )
                 signal = interp1(
@@ -1168,7 +1168,7 @@ class EastPhysicsMethods:
         try:
             lh_signals = {}
             for name, node in lh_nodes.items():
-                signal, timearray = params.mds_conn.get_data_with_dims(
+                signal, timearray = params.data_conn.get_data_with_dims(
                     node, tree_name="pefitrt_east"
                 )
                 signal = interp1(
@@ -1217,7 +1217,7 @@ class EastPhysicsMethods:
         Parameters
         ----------
         params : PhysicsMethodParams
-            The parameters containing the MDS connection and shot information.
+            The parameters containing the data connection and shot information.
 
         Returns
         -------
@@ -1287,7 +1287,7 @@ class EastPhysicsMethods:
         Parameters
         ----------
         params : PhysicsMethodParams
-            The parameters containing the MDS connection and shot information.
+            The parameters containing the data connection and shot information.
 
         Returns
         -------
@@ -1312,7 +1312,7 @@ class EastPhysicsMethods:
 
         # Get the Mirnov signal from \cmp1t (5 MHz)
         time_window = 0.001
-        bp_dot, bp_dot_time = params.mds_conn.get_data_with_dims(
+        bp_dot, bp_dot_time = params.data_conn.get_data_with_dims(
             r"\cmp1t", tree_name="east"
         )  # [T/s], [s]
         for i, time in enumerate(params.times):
@@ -1342,7 +1342,7 @@ class EastPhysicsMethods:
         Parameters
         ----------
         params : PhysicsMethodParams
-            The parameters containing the MDS connection and shot information.
+            The parameters containing the data connection and shot information.
 
         Returns
         -------
@@ -1365,7 +1365,7 @@ class EastPhysicsMethods:
         n1rms_normalized = [np.nan]
         n2rms_normalized = [np.nan]
 
-        (mirtime,) = params.mds_conn.get_dims(r"\mitab2", tree_name="east")
+        (mirtime,) = params.data_conn.get_dims(r"\mitab2", tree_name="east")
         mir = np.full((len(mirtime), 16), np.nan)
         mir_nodes = [
             r"\mitab2",
@@ -1387,7 +1387,7 @@ class EastPhysicsMethods:
         ]
         for i, node in enumerate(mir_nodes):
             try:
-                mir[:, i] = params.mds_conn.get_data(node, tree_name="east")
+                mir[:, i] = params.data_conn.get_data(node, tree_name="east")
             except mdsExceptions.MdsException:
                 continue
 
@@ -1431,7 +1431,7 @@ class EastPhysicsMethods:
         Parameters
         ----------
         params : PhysicsMethodParams
-            Parameters containing MDS connection and shot information
+            Parameters containing data connection and shot information
 
         Returns
         -------
@@ -1445,7 +1445,7 @@ class EastPhysicsMethods:
         """
         h98_y2 = [np.nan]
 
-        h98_y2, h98_y2_time = params.mds_conn.get_data_with_dims(
+        h98_y2, h98_y2_time = params.data_conn.get_data_with_dims(
             r"\h98_mhd", tree_name="energy_east"
         )
 
@@ -1463,7 +1463,7 @@ class EastPhysicsMethods:
         lower_gap = [np.nan]
 
         # Get plasma boundary data
-        data, efittime = params.mds_conn.get_data_with_dims(
+        data, efittime = params.data_conn.get_data_with_dims(
             r"\top.results.geqdsk:bdry", tree_name=tree
         )
         # Convert the order of indices to MATLAB order
@@ -1472,10 +1472,10 @@ class EastPhysicsMethods:
         xcoords, ycoords = data
 
         # Get first wall geometry data
-        xfirstwall = params.mds_conn.get_data(
+        xfirstwall = params.data_conn.get_data(
             r"\top.results.geqdsk:xlim", tree_name=tree
         )
-        yfirstwall = params.mds_conn.get_data(
+        yfirstwall = params.data_conn.get_data(
             r"\top.results.geqdsk:ylim", tree_name=tree
         )
         seed = np.ones((len(xcoords), 1))
@@ -1549,7 +1549,7 @@ class EastPhysicsMethods:
         Parameters
         ----------
         params : PhysicsMethodParams
-            Parameters containing MDS connection and shot information
+            Parameters containing data connection and shot information
 
         Returns
         -------

--- a/disruption_py/machine/east/util.py
+++ b/disruption_py/machine/east/util.py
@@ -42,7 +42,7 @@ class EastUtilMethods:
         return ip
 
     @staticmethod
-    def retrieve_ip(mds_conn: MDSConnection, shot_id: int):
+    def retrieve_ip(data_conn: MDSConnection, shot_id: int):
         """
         Read in the measured plasma current, Ip. There are several different
         measurements of Ip: IPE, IPG, IPM (all in the EAST tree), and PCRL01
@@ -54,8 +54,8 @@ class EastUtilMethods:
 
         Parameters
         ----------
-        mds_conn : MDSConnection
-            MDSplus connection for the shot.
+        data_conn : MDSConnection
+            Data connection for the shot.
         shot_id : int
             Shot number.
 
@@ -65,7 +65,7 @@ class EastUtilMethods:
             Plasma current [A], time base of plasma current [s].
         """
 
-        ip, ip_time = mds_conn.get_data_with_dims(
+        ip, ip_time = data_conn.get_data_with_dims(
             r"\pcrl01", tree_name="pcs_east"
         )  # [A], [s]
 

--- a/disruption_py/machine/generic/physics.py
+++ b/disruption_py/machine/generic/physics.py
@@ -35,7 +35,7 @@ class GenericPhysicsMethods:
         Parameters
         ----------
         params : PhysicsMethodParams
-            The parameters containing the MDSplus connection, shot id and more.
+            The parameters containing the data connection, shot id and more.
 
         Returns
         -------

--- a/disruption_py/machine/hbtep/physics.py
+++ b/disruption_py/machine/hbtep/physics.py
@@ -32,7 +32,7 @@ class HbtepPhysicsMethods:
         """
         Get the plasma current
         """
-        ip, t_ip = params.mds_conn.get_data_with_dims(
+        ip, t_ip = params.data_conn.get_data_with_dims(
             r"\top.sensors.rogowskis:ip", tree_name="hbtep2"
         )  # [A], [s]
         ip = interp1(t_ip, ip, params.times, "linear")
@@ -44,10 +44,10 @@ class HbtepPhysicsMethods:
         """
         Get the ohmic heating and vertical field coil currents
         """
-        i_vfc, t_vfc = params.mds_conn.get_data_with_dims(
+        i_vfc, t_vfc = params.data_conn.get_data_with_dims(
             r"\top.sensors.vf_current", tree_name="hbtep2"
         )  # [A], [s]
-        i_ohc, t_ohc = params.mds_conn.get_data_with_dims(
+        i_ohc, t_ohc = params.data_conn.get_data_with_dims(
             r"\top.sensors.oh_current", tree_name="hbtep2"
         )  # [A], [s]
         i_vfc = interp1(t_vfc, i_vfc, params.times, "linear")
@@ -71,21 +71,21 @@ class HbtepPhysicsMethods:
         oh_pickup = 7.0723416e-08
 
         # get vf and oh data
-        i_vfc, t_vfc = params.mds_conn.get_data_with_dims(
+        i_vfc, t_vfc = params.data_conn.get_data_with_dims(
             r"\top.sensors.vf_current", tree_name="hbtep2"
         )  # [A], [s]
-        i_ohc, t_ohc = params.mds_conn.get_data_with_dims(
+        i_ohc, t_ohc = params.data_conn.get_data_with_dims(
             r"\top.sensors.oh_current", tree_name="hbtep2"
         )  # [A], [s]
 
         # get plasma current
-        ip, t_ip = params.mds_conn.get_data_with_dims(
+        ip, t_ip = params.data_conn.get_data_with_dims(
             r"\top.sensors.rogowskis:ip", tree_name="hbtep2"
         )  # [A], [s]
         ip *= 1212.3 * 1e-9  # ip gain
 
         # get cosine Rogowski data
-        cos1_raw, t_cos1_raw = params.mds_conn.get_data_with_dims(
+        cos1_raw, t_cos1_raw = params.data_conn.get_data_with_dims(
             r"\top.sensors.rogowskis:cos_1:raw", tree_name="hbtep2"
         )  # [A/s], [s]
         # calculate and subtract offset
@@ -140,7 +140,7 @@ class HbtepPhysicsMethods:
         """
         Calculate B_tor from the TF probe data
         """
-        btor, t_btor = params.mds_conn.get_data_with_dims(
+        btor, t_btor = params.data_conn.get_data_with_dims(
             r"\top.sensors.tf_probe", tree_name="hbtep2"
         )  # [T], [s]
         btor = interp1(t_btor, btor, params.times, "linear")
@@ -171,7 +171,7 @@ class HbtepPhysicsMethods:
         """
         Get v_loop measurement
         """
-        v_loop, t_v_loop = params.mds_conn.get_data_with_dims(
+        v_loop, t_v_loop = params.data_conn.get_data_with_dims(
             r"\top.sensors.loop_voltage", tree_name="hbtep2"
         )  # [V], [s]
         v_loop = interp1(t_v_loop, v_loop, params.times, "linear")
@@ -183,7 +183,7 @@ class HbtepPhysicsMethods:
         """
         Get D alpha line emission from spectrometer
         """
-        h_alpha, t_h_alpha = params.mds_conn.get_data_with_dims(
+        h_alpha, t_h_alpha = params.data_conn.get_data_with_dims(
             r"\top.sensors.spectrometer", tree_name="hbtep2"
         )  # [arb], [s]
         h_alpha = interp1(t_h_alpha, h_alpha, params.times, "linear")
@@ -195,7 +195,7 @@ class HbtepPhysicsMethods:
         """
         Get the soft x-ray midplane sensor data
         """
-        sxr, t_sxr = params.mds_conn.get_data_with_dims(
+        sxr, t_sxr = params.data_conn.get_data_with_dims(
             r"\top.devices.north_rack:cpci:input_74", tree_name="hbtep2"
         )  # [arb], [s]
         # offset subtraction
@@ -506,7 +506,7 @@ class HbtepPhysicsMethods:
         ta_pol_data_filt = []
         ta_pol_time = []
         for sensor_name in output["ta_pol_names"]:
-            sensor_data_raw, sensor_time = params.mds_conn.get_data_with_dims(
+            sensor_data_raw, sensor_time = params.data_conn.get_data_with_dims(
                 r"\top.sensors.magnetic:" + sensor_name, tree_name="hbtep2"
             )  # [T], [s]
             fs_ta_pol = round(1 / (sensor_time[1] - sensor_time[0]))
@@ -520,7 +520,7 @@ class HbtepPhysicsMethods:
         ta_rad_data_filt = []
         ta_rad_time = []
         for sensor_name in output["ta_rad_names"]:
-            sensor_data_raw, sensor_time = params.mds_conn.get_data_with_dims(
+            sensor_data_raw, sensor_time = params.data_conn.get_data_with_dims(
                 r"\top.sensors.magnetic:" + sensor_name, tree_name="hbtep2"
             )  # [T], [s]
             fs_ta_rad = round(1 / (sensor_time[1] - sensor_time[0]))
@@ -635,7 +635,7 @@ class HbtepPhysicsMethods:
         pa1_data_filt = []
         pa1_time = []
         for sensor_name in output["pa1_names"]:
-            sensor_data_raw, sensor_time = params.mds_conn.get_data_with_dims(
+            sensor_data_raw, sensor_time = params.data_conn.get_data_with_dims(
                 r"\top.sensors.magnetic:" + sensor_name, tree_name="hbtep2"
             )
             fs_pa1 = round(1 / (sensor_time[1] - sensor_time[0]))
@@ -649,7 +649,7 @@ class HbtepPhysicsMethods:
         pa2_data_filt = []
         pa2_time = []
         for sensor_name in output["pa2_names"]:
-            sensor_data_raw, sensor_time = params.mds_conn.get_data_with_dims(
+            sensor_data_raw, sensor_time = params.data_conn.get_data_with_dims(
                 r"\top.sensors.magnetic:" + sensor_name, tree_name="hbtep2"
             )
             fs_pa2 = round(1 / (sensor_time[1] - sensor_time[0]))
@@ -682,7 +682,7 @@ class HbtepPhysicsMethods:
         output["sensor_num"] = [1, 2, 3, 4, 6, 9, 11, 12, 14, 16]
         # channels = output['sensor_num'] + 75
 
-        time = params.mds_conn.get_dims(
+        time = params.data_conn.get_dims(
             r"\top.sensors.sxr_fan.channel_01:raw", tree_name="hbtep2"
         )
         output["time"] = time[0]
@@ -694,25 +694,25 @@ class HbtepPhysicsMethods:
         midplane = []
         for n in output["sensor_num"]:
             data.append(
-                params.mds_conn.get_data(
+                params.data_conn.get_data(
                     rf"\top.sensors.sxr_fan.channel_{n:02d}:raw",
                     tree_name="hbtep2",
                 )
             )
             r.append(
-                params.mds_conn.get_data(
+                params.data_conn.get_data(
                     rf"\top.sensors.sxr_fan.channel_{n:02d}:r",
                     tree_name="hbtep2",
                 )
             )
             z.append(
-                params.mds_conn.get_data(
+                params.data_conn.get_data(
                     rf"\top.sensors.sxr_fan.channel_{n:02d}:z",
                     tree_name="hbtep2",
                 )
             )
             midplane.append(
-                params.mds_conn.get_data(
+                params.data_conn.get_data(
                     rf"\top.sensors.sxr_fan.channel_{n:02d}:midplane",
                     tree_name="hbtep2",
                 )
@@ -739,7 +739,7 @@ class HbtepPhysicsMethods:
         output = {}
         output["detectors"] = [0, 25, 90, 270]  # poloidal location of the 4 fan arrays
 
-        time = params.mds_conn.get_dims(
+        time = params.data_conn.get_dims(
             r"\top.sensors.euv.pol.det000.channel_01:raw", tree_name="hbtep2"
         )
         output["time"] = time[0]
@@ -751,12 +751,12 @@ class HbtepPhysicsMethods:
                     rf"\top.sensors.euv.pol.det{detector:03d}.channel_{channel:02d}"
                 )
                 data.append(
-                    params.mds_conn.get_data(address + ":raw", tree_name="hbtep2")
+                    params.data_conn.get_data(address + ":raw", tree_name="hbtep2")
                 )
-                r.append(params.mds_conn.get_data(address + ":r", tree_name="hbtep2"))
-                z.append(params.mds_conn.get_data(address + ":z", tree_name="hbtep2"))
+                r.append(params.data_conn.get_data(address + ":r", tree_name="hbtep2"))
+                z.append(params.data_conn.get_data(address + ":z", tree_name="hbtep2"))
                 gain.append(
-                    params.mds_conn.get_data(address + ":gain", tree_name="hbtep2")
+                    params.data_conn.get_data(address + ":gain", tree_name="hbtep2")
                 )
             output[f"euv_{detector:03d}_data"] = data
             output[f"euv_{detector:03d}_r"] = r

--- a/disruption_py/machine/mast/efit.py
+++ b/disruption_py/machine/mast/efit.py
@@ -50,7 +50,7 @@ class MastEfitMethods:
         dict
             A dictionary containing the retrieved EFIT parameters.
         """
-        conn = params.mds_conn
+        conn = params.data_conn
         eq_time = conn.get_data("equilibrium/time")
         times = params.times
 

--- a/disruption_py/machine/mast/physics.py
+++ b/disruption_py/machine/mast/physics.py
@@ -42,7 +42,7 @@ class MastPhysicsMethods:
             A dictionary containing plasma current (`ip`), its time derivative (`dip_dt`),
             programmed plasma current (`ip_prog`), and its time derivative (`dipprog_dt`).
         """
-        conn = params.mds_conn
+        conn = params.data_conn
         ip = conn.get_data("summary/ip")
         ip_prog = conn.get_data("pulse_schedule/i_plasma")
         ip_prog_time = conn.get_data("pulse_schedule/time")
@@ -84,7 +84,7 @@ class MastPhysicsMethods:
             A dictionary containing neutral beam injection power (`power_nbi`) and
             radiated power (`power_radiated`).
         """
-        conn = params.mds_conn
+        conn = params.data_conn
 
         power_nbi = conn.get_data("summary/power_nbi")
         power_radiated = conn.get_data("summary/power_radiated")
@@ -116,7 +116,7 @@ class MastPhysicsMethods:
             A dictionary containing total injected gas (`total_injected`),
             inboard total gas (`inboard_total`), and outboard total gas (`outboard_total`).
         """
-        conn = params.mds_conn
+        conn = params.data_conn
 
         total_injected = conn.get_data("gas_injection/total_injected")
         inboard_total = conn.get_data("gas_injection/inboard_total")
@@ -157,7 +157,7 @@ class MastPhysicsMethods:
             core electron density (`n_e_core`).
         """
         times = params.times
-        conn = params.mds_conn
+        conn = params.data_conn
 
         t_e_core = conn.get_data("thomson_scattering/t_e_core")
         n_e_core = conn.get_data("thomson_scattering/n_e_core")
@@ -200,7 +200,7 @@ class MastPhysicsMethods:
 
         """
 
-        conn = params.mds_conn
+        conn = params.data_conn
         n_e = conn.get_data("summary/line_average_n_e")
         t_n = conn.get_data("summary/time")
         ip = conn.get_data("summary/ip")
@@ -275,7 +275,7 @@ class MastPhysicsMethods:
             A dictionary containing SXR data (`sxr_data`) and
             corresponding time points (`sxr_time`).
         """
-        conn = params.mds_conn
+        conn = params.data_conn
         hcam = conn.get_data("soft_x_rays/horizontal_cam_upper", return_xarray=True)
 
         if hcam is not None:
@@ -311,7 +311,7 @@ class MastPhysicsMethods:
         dict
             A dictionary containing D-alpha signal data (`dalpha`).
         """
-        conn = params.mds_conn
+        conn = params.data_conn
 
         dalpha = conn.get_data(
             "spectrometer_visible/filter_spectrometer_dalpha_voltage",

--- a/disruption_py/settings/nickname_setting.py
+++ b/disruption_py/settings/nickname_setting.py
@@ -30,7 +30,7 @@ class NicknameSettingParams:
     ----------
     shot_id : int
         The shot ID for which to resolve nicknames.
-    mds_conn : DataConnection
+    data_conn : DataConnection
         Data connection for the shot.
     database : ShotDatabase
         Database connection for querying tokamak shot data.
@@ -41,7 +41,7 @@ class NicknameSettingParams:
     """
 
     shot_id: int
-    mds_conn: DataConnection
+    data_conn: DataConnection
     database: ShotDatabase
     disruption_time: float
     tokamak: Tokamak

--- a/disruption_py/settings/time_setting.py
+++ b/disruption_py/settings/time_setting.py
@@ -33,7 +33,7 @@ class TimeSettingParams:
     ----------
     shot_id : int
         Shot ID for the timebase being created.
-    mds_conn : DataConnection
+    data_conn : DataConnection
         Data connection for the shot.
     database : ShotDatabase
         Database object with connection to the SQL database.
@@ -44,7 +44,7 @@ class TimeSettingParams:
     """
 
     shot_id: int
-    mds_conn: DataConnection
+    data_conn: DataConnection
     database: ShotDatabase
     disruption_time: float
     tokamak: Tokamak
@@ -258,16 +258,16 @@ class EfitTimeSetting(TimeSetting):
         np.ndarray
             Array of times in the timebase.
         """
-        (efit_time,) = params.mds_conn.get_dims(
+        (efit_time,) = params.data_conn.get_dims(
             r"\efit_aeqdsk:ali", tree_name="_efit_tree"
         )
-        efit_time_unit = params.mds_conn.get_data(
+        efit_time_unit = params.data_conn.get_data(
             r"units_of(dim_of(\efit_aeqdsk:ali))", tree_name="_efit_tree"
         )
         if efit_time_unit not in {"s", "ms", "us"}:
             params.logger.verbose(
                 "Failed to get the time units of EFIT tree '{tree}', assuming seconds.",
-                tree=params.mds_conn.get_tree_name_of_nickname("_efit_tree"),
+                tree=params.data_conn.get_tree_name_of_nickname("_efit_tree"),
             )
         return _postprocess(times=efit_time, units=efit_time_unit)
 
@@ -285,7 +285,7 @@ class EfitTimeSetting(TimeSetting):
         np.ndarray
             Array of times in the timebase.
         """
-        efit_time = MastUtilMethods.retrieve_efit_time(params.mds_conn)
+        efit_time = MastUtilMethods.retrieve_efit_time(params.data_conn)
         return efit_time
 
 
@@ -338,7 +338,7 @@ class DisruptionTimeSetting(TimeSetting):
         np.ndarray
             Array of times in the timebase.
         """
-        raw_ip, ip_time = params.mds_conn.get_data_with_dims(
+        raw_ip, ip_time = params.data_conn.get_data_with_dims(
             f"ptdata('ip', {params.shot_id})"
         )
         ip_time = ip_time / 1.0e3
@@ -360,7 +360,7 @@ class DisruptionTimeSetting(TimeSetting):
         np.ndarray
             Array of times in the timebase.
         """
-        ip, ip_time = EastUtilMethods.retrieve_ip(params.mds_conn, params.shot_id)
+        ip, ip_time = EastUtilMethods.retrieve_ip(params.data_conn, params.shot_id)
         return self._calculate_disruption_times(params, ip, ip_time)
 
     def hbtep_times(self, params: TimeSettingParams) -> np.ndarray:
@@ -372,7 +372,7 @@ class DisruptionTimeSetting(TimeSetting):
         This will be replaced once a get_disruption_time method is implemented for HBT-EP
         """
 
-        t_ip = params.mds_conn.get_dims(
+        t_ip = params.data_conn.get_dims(
             r"\top.sensors.rogowskis:ip", tree_name="hbtep2"
         )  # [s]
         t_ip = t_ip[0]
@@ -394,7 +394,7 @@ class DisruptionTimeSetting(TimeSetting):
         np.ndarray
             Array of times in the timebase.
         """
-        ip, ip_time = MastUtilMethods.retrieve_ip(params.mds_conn)
+        ip, ip_time = MastUtilMethods.retrieve_ip(params.data_conn)
         return self._calculate_disruption_times(params, ip, ip_time)
 
     @classmethod
@@ -568,7 +568,7 @@ class IpTimeSetting(TimeSetting):
         np.ndarray
             Array of times in the timebase.
         """
-        (ip_time,) = params.mds_conn.get_dims(r"\ip", tree_name="magnetics")
+        (ip_time,) = params.data_conn.get_dims(r"\ip", tree_name="magnetics")
         return ip_time
 
     def d3d_times(self, params: TimeSettingParams) -> np.ndarray:
@@ -585,7 +585,7 @@ class IpTimeSetting(TimeSetting):
         np.ndarray
             Array of times in the timebase.
         """
-        (ip_time,) = params.mds_conn.get_dims(f"ptdata('ip', {params.shot_id})")
+        (ip_time,) = params.data_conn.get_dims(f"ptdata('ip', {params.shot_id})")
         ip_time /= 1e3  # [ms] -> [s]
         return ip_time
 
@@ -603,7 +603,7 @@ class IpTimeSetting(TimeSetting):
         np.ndarray
             Array of times in the timebase.
         """
-        (ip_time,) = params.mds_conn.get_dims(r"\pcrl01", tree_name="pcs_east")
+        (ip_time,) = params.data_conn.get_dims(r"\pcrl01", tree_name="pcs_east")
         # For shots before year 2014, the PCRL01 timebase needs to be shifted
         # by 17.0 ms
         if params.shot_id < 44432:
@@ -624,7 +624,7 @@ class IpTimeSetting(TimeSetting):
         np.ndarray
             Array of times in the timebase.
         """
-        (ip_time,) = params.mds_conn.get_dims(
+        (ip_time,) = params.data_conn.get_dims(
             r"\top.sensors.rogowskis:ip", tree_name="hbtep2"
         )
         return ip_time
@@ -643,7 +643,7 @@ class IpTimeSetting(TimeSetting):
         np.ndarray
             Array of times in the timebase.
         """
-        _, ip_time = MastUtilMethods.retrieve_ip(params.mds_conn)
+        _, ip_time = MastUtilMethods.retrieve_ip(params.data_conn)
         return ip_time
 
 
@@ -695,7 +695,7 @@ class SignalTimeSetting(TimeSetting):
             Array of times in the timebase.
         """
         try:
-            (signal_time,) = params.mds_conn.get_dims(
+            (signal_time,) = params.data_conn.get_dims(
                 self.signal_path, tree_name=self.tree_name
             )
         except mdsExceptions.MdsException:
@@ -704,7 +704,7 @@ class SignalTimeSetting(TimeSetting):
                 signal_path=self.signal_path,
             )
             raise
-        signal_unit = params.mds_conn.get_data(
+        signal_unit = params.data_conn.get_data(
             f"units_of(dim_of({self.signal_path}))", tree_name=self.tree_name
         )
         if (

--- a/disruption_py/workflow.py
+++ b/disruption_py/workflow.py
@@ -59,13 +59,13 @@ def _execute_retrieval(args):
     tuple of shot id and the dataframe
     """
     tokamak, db_init, conn_init, retrieval_settings, shot_id = args
-    database = _get_database_instance(tokamak, db_init)
-    data_conn = _get_connection_instance(tokamak, conn_init)
+    process_database = _get_database_instance(tokamak, db_init)
+    process_data_conn = _get_connection_instance(tokamak, conn_init)
 
     retrieval_manager = RetrievalManager(
         tokamak=tokamak,
-        process_database=database,
-        process_data_conn=data_conn,
+        process_database=process_database,
+        process_data_conn=process_data_conn,
     )
     return shot_id, retrieval_manager.get_shot_data(shot_id, retrieval_settings)
 

--- a/disruption_py/workflow.py
+++ b/disruption_py/workflow.py
@@ -51,21 +51,21 @@ def _execute_retrieval(args):
     Params
     ------
     args : List
-        tokamak, database initializer, mds connection initializer, retrieval
+        tokamak, database initializer, connection initializer, retrieval
         settings, and the shot id
 
     Returns
     -------
     tuple of shot id and the dataframe
     """
-    tokamak, db_init, mds_init, retrieval_settings, shot_id = args
+    tokamak, db_init, conn_init, retrieval_settings, shot_id = args
     database = _get_database_instance(tokamak, db_init)
-    mds_conn = _get_mds_instance(tokamak, mds_init)
+    data_conn = _get_connection_instance(tokamak, conn_init)
 
     retrieval_manager = RetrievalManager(
         tokamak=tokamak,
         process_database=database,
-        process_mds_conn=mds_conn,
+        process_data_conn=data_conn,
     )
     return shot_id, retrieval_manager.get_shot_data(shot_id, retrieval_settings)
 
@@ -74,21 +74,29 @@ def get_shots_data(
     shotlist_setting: ShotlistSettingType,
     tokamak: Tokamak = None,
     database_initializer: Callable[..., ShotDatabase] = None,
-    mds_connection_initializer: Callable[..., ProcessConnection] = None,
+    connection_initializer: Callable[..., ProcessConnection] = None,
     retrieval_settings: RetrievalSettings = None,
     output_setting: OutputSetting = "dataset",
     num_processes: int = 1,
     log_settings: LogSettings = None,
 ) -> Any:
     """
-    Get shot data for all shots from shotlist_setting from CMOD.
+    Get shot data for all shots specified by shotlist_setting.
 
-    Attributes
+    Parameters
     ----------
     shotlist_setting : ShotlistSettingType
         Data retrieved for all shotlist specified by the setting. See ShotlistSetting
         for more details.
-    retrieval_settings : RetrievalSettings
+    tokamak : Tokamak, optional
+        The tokamak to retrieve data for. If None, detected from the environment.
+    database_initializer : Callable[..., ShotDatabase], optional
+        Factory for creating a database connection. If None, the default database
+        for the tokamak is used.
+    connection_initializer : Callable[..., ProcessConnection], optional
+        Factory for creating a process-level data connection. If None, the default
+        connection for the tokamak is used.
+    retrieval_settings : RetrievalSettings, optional
         The settings that each shot uses when retrieving data. See RetrievalSettings
         for more details. If None, the default values of each setting in
         RetrievalSettings is used.
@@ -100,8 +108,9 @@ def get_shots_data(
     num_processes : int
         The number of processes to use for data retrieval. If 1, the data is retrieved
         in serial. If > 1, the data is retrieved in parallel.
-    log_settings : LogSettings
+    log_settings : LogSettings, optional
         Settings for logging.
+
     Returns
     -------
     Any
@@ -168,7 +177,7 @@ def get_shots_data(
         args = zip(
             repeat(tokamak),
             repeat(database_initializer),
-            repeat(mds_connection_initializer),
+            repeat(connection_initializer),
             repeat(retrieval_settings),
             shotlist_list,
         )
@@ -244,12 +253,12 @@ def _get_database_instance(tokamak, database_initializer):
     return get_database(tokamak)
 
 
-def _get_mds_instance(tokamak, mds_connection_initializer):
+def _get_connection_instance(tokamak, connection_initializer):
     """
-    Create MDSplus instance
+    Create process connection instance
     """
-    if mds_connection_initializer:
-        return mds_connection_initializer()
+    if connection_initializer:
+        return connection_initializer()
     return get_process_connection(tokamak)
 
 

--- a/docs/examples/custom_physics_method.py
+++ b/docs/examples/custom_physics_method.py
@@ -43,9 +43,9 @@ def decorated_physics_method(params: PhysicsMethodParams) -> dict:
 # pylint: disable=duplicate-code
 @physics_method(columns=["custom_kappa_area"], tokamak=Tokamak.CMOD)
 def get_custom_kappa_area(params: PhysicsMethodParams):
-    aminor = params.mds_conn.get_data(r"\efit_aeqdsk:aminor", tree_name="_efit_tree")
-    area = params.mds_conn.get_data(r"\efit_aeqdsk:area", tree_name="_efit_tree")
-    times = params.mds_conn.get_data(r"\efit_aeqdsk:time", tree_name="_efit_tree")
+    aminor = params.data_conn.get_data(r"\efit_aeqdsk:aminor", tree_name="_efit_tree")
+    area = params.data_conn.get_data(r"\efit_aeqdsk:area", tree_name="_efit_tree")
+    times = params.data_conn.get_data(r"\efit_aeqdsk:time", tree_name="_efit_tree")
 
     # Ensure aminor and area are not 0 or less than 0
     aminor[aminor <= 0] = 0.001

--- a/docs/examples/custom_time_setting.py
+++ b/docs/examples/custom_time_setting.py
@@ -11,7 +11,7 @@ class PRadTime(TimeSetting):
 
     def _get_times(self, params: TimeSettingParams):
         """Return prad times"""
-        (time_array,) = params.mds_conn.get_dims(
+        (time_array,) = params.data_conn.get_dims(
             r"\twopi_diode", tree_name="spectroscopy"
         )
         time_array = time_array[time_array > 0]

--- a/docs/usage/data_connection_reference.md
+++ b/docs/usage/data_connection_reference.md
@@ -1,0 +1,18 @@
+DisruptionPy defines abstract base classes for data connections, allowing physics methods to work with any backend (MDSplus, Xarray/Zarr, etc.) through a unified interface.
+
+## Connection Architecture { .doc .doc-heading }
+
+[`DataConnection`][disruption_py.inout.base.DataConnection] is the per-shot data access interface. Each instance is bound to a single shot and provides methods for retrieving data and dimensions. Concrete implementations include [`MDSConnection`][disruption_py.inout.mds.MDSConnection] for MDSplus and `XarrayDataConnection` for Xarray/Zarr.
+
+[`ProcessConnection`][disruption_py.inout.base.ProcessConnection] is the per-process factory that creates `DataConnection` instances for each shot. This separation ensures multiprocessing safety -- each process holds its own `ProcessConnection`, which produces independent `DataConnection` objects per shot.
+
+## Base Class Reference { .doc .doc-heading }
+
+::: disruption_py.inout.base
+    handler: python
+    options:
+        heading_level: 3
+        show_root_heading: false
+        show_root_toc_entry: false
+        filters: ["!^_[^_]"]
+        members_order: "source"

--- a/docs/usage/physics_methods/physics_method_reference.md
+++ b/docs/usage/physics_methods/physics_method_reference.md
@@ -41,7 +41,7 @@ def ***_method(params: PhysicsMethodParams) -> dict:
 
 2. To retrieve data from MDSplus use the `params` ([`PhysicsMethodParams`][disruption_py.core.physics_method.params.PhysicsMethodParams]) object. It contains many useful attributes, among which are the following:
     - `params.shot_id`: the shot id of the shot for which data is being retrieved.
-	- `params.mds_conn`: a wrapper around the MDSplus connection for the process, that makes it easier to get data for a shot. See [`MDSConnection`][disruption_py.inout.mds.MDSConnection] for details.
+	- `params.data_conn`: the data connection for the shot, used to retrieve data. See [`DataConnection`][disruption_py.inout.base.DataConnection] for details.
     - `params.times`: the timebase of the shot for which data is being retrieved as a NumPy array of times.
 ??? example "Shot Data Request Examples"
 

--- a/docs/usage/physics_methods/physics_method_reference.md
+++ b/docs/usage/physics_methods/physics_method_reference.md
@@ -39,7 +39,7 @@ def ***_method(params: PhysicsMethodParams) -> dict:
 	...
 ```
 
-2. To retrieve data from MDSplus use the `params` ([`PhysicsMethodParams`][disruption_py.core.physics_method.params.PhysicsMethodParams]) object. It contains many useful attributes, among which are the following:
+2. To retrieve data use the `params` ([`PhysicsMethodParams`][disruption_py.core.physics_method.params.PhysicsMethodParams]) object. It contains many useful attributes, among which are the following:
     - `params.shot_id`: the shot id of the shot for which data is being retrieved.
 	- `params.data_conn`: the data connection for the shot, used to retrieve data. See [`DataConnection`][disruption_py.inout.base.DataConnection] for details.
     - `params.times`: the timebase of the shot for which data is being retrieved as a NumPy array of times.

--- a/examples/defaults.py
+++ b/examples/defaults.py
@@ -24,7 +24,7 @@ shot_data = get_shots_data(
     shotlist_setting=[],
     # default None: detect from environment
     tokamak=None,
-    # default None: standard SQL/MDSplus connection
+    # default None: standard backend connection(s)
     database_initializer=None,
     connection_initializer=None,
     retrieval_settings=retrieval_settings,

--- a/examples/defaults.py
+++ b/examples/defaults.py
@@ -26,7 +26,7 @@ shot_data = get_shots_data(
     tokamak=None,
     # default None: standard SQL/MDSplus connection
     database_initializer=None,
-    mds_connection_initializer=None,
+    connection_initializer=None,
     retrieval_settings=retrieval_settings,
     output_setting="dataset",
     num_processes=1,

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -61,6 +61,7 @@ nav:
           - Parameter Reference: "usage/physics_methods/\
             disruption_parameters_reference.md"
       - Data I/O:
+          - Data Connection (Base): usage/data_connection_reference.md
           - SQL Database: usage/sql_database.md
           - MDSplus Connection: usage/mds_connection_reference.md
   - GitHub: https://github.com/MIT-PSFC/disruption-py


### PR DESCRIPTION
 ## Summary
  - Renamed `mds_conn` → `data_conn`, `process_mds_conn` → `process_data_conn`, `_get_mds_instance` → `_get_connection_instance` to reflect the backend-agnostic `DataConnection` ABC
   introduced in #523
  - Renamed public API parameter `mds_connection_initializer` → `connection_initializer` in `get_shots_data()` (takes `ProcessConnection`, not MDS-specific)
  - Updated user-facing docs (`physics_method_reference.md`, `examples/defaults.py`, `docs/examples/`)
  - Fixed incomplete `get_shots_data()` docstring (missing params, stale "from CMOD" wording)

  ## Details
  24 files, ~370 line changes. Pure rename + formatting — no behavioral changes.

  ## Test plan
  - [x] CI passes (rename is mechanical; no logic changes)
  - [ ] Bit-identical validation (covered by #523 validation, this PR stacks on it)