### PR TITLE
Fix CLI return code

### DIFF
--- a/disruption_py/workflow.py
+++ b/disruption_py/workflow.py
@@ -295,7 +295,7 @@ def cli():
 
     out = run(**vars(parser.parse_args()))
     print(out)
-    return len(out) == 0
+    return 2 if out is None else len(out) == 0
 
 
 if __name__ == "__main__":

--- a/disruption_py/workflow.py
+++ b/disruption_py/workflow.py
@@ -299,4 +299,4 @@ def cli():
 
 
 if __name__ == "__main__":
-    cli()
+    sys.exit(cli())

--- a/disruption_py/workflow.py
+++ b/disruption_py/workflow.py
@@ -295,7 +295,7 @@ def cli():
 
     out = run(**vars(parser.parse_args()))
     print(out)
-    return not len(out)
+    return len(out) == 0
 
 
 if __name__ == "__main__":

--- a/disruption_py/workflow.py
+++ b/disruption_py/workflow.py
@@ -293,7 +293,9 @@ def cli():
     parser.add_argument("-p", "--processes", type=int, default=1)
     parser.add_argument("-l", "--log-level", type=str, default="VERBOSE")
 
-    print(run(**vars(parser.parse_args())))
+    out = run(**vars(parser.parse_args()))
+    print(out)
+    return not len(out)
 
 
 if __name__ == "__main__":

--- a/disruption_py/workflow.py
+++ b/disruption_py/workflow.py
@@ -293,9 +293,8 @@ def cli():
     parser.add_argument("-p", "--processes", type=int, default=1)
     parser.add_argument("-l", "--log-level", type=str, default="VERBOSE")
 
-    return run(**vars(parser.parse_args()))
+    print(run(**vars(parser.parse_args())))
 
 
 if __name__ == "__main__":
-    out = cli()
-    print(out)
+    cli()

--- a/makefile
+++ b/makefile
@@ -71,7 +71,10 @@ release:
 
 # test #
 
-.PHONY: quick test test-fast
+.PHONY: go quick test test-fast
+
+go:
+	poetry run disruption-py -l debug
 
 quick:
 	poetry run pytest -v tests/test_quick.py


### PR DESCRIPTION
now one can easily chain multiple commands through make-style return codes, eg:

```
make install go test-fast test
```

previously, all work was carried out by pytest and so it was not immediately clear which tokamak the workflow was targeting.
now, the `go` target should make it apparent.