### PR TITLE
Add disruption-errors utility workflow

### DIFF
--- a/scripts/disruption-errors.ignore
+++ b/scripts/disruption-errors.ignore
@@ -1,0 +1,7 @@
+MDSPLUS-E-ERROR
+MDSplusERROR
+NotImplementedError
+parameters have data
+Pathological timebase
+TreeFOPENR
+TreeNODATA

--- a/scripts/disruption-errors.sh
+++ b/scripts/disruption-errors.sh
@@ -10,7 +10,10 @@
 # can optionally digest a previous log file, instead.
 # then, it parses the log file and collects all errors and critical messages,
 # excluding those that match the patterns in the sibling .ignore file.
-# finally, it prints a list of errors, together with their relative frequency.
+# finally, it prints a useful summary, consisting of:
+# - a (red) list of unique errors, together with their relative frequency;
+# - a (yellow) list of error examples, one per unique error;
+# - a (green) list of shot numbers, one per unique error.
 #
 # usage examples:
 #
@@ -25,7 +28,9 @@ IGNORE="${BASH_SOURCE[0]%.sh}.ignore"
 TMPD="${LOCALSCRATCH:-/tmp}/$USER/disruption-py/.$(date +%F)"
 mkdir -p "$TMPD" || exit 10
 TMPF=$(mktemp -p "$TMPD" "errors-$(date +%s)-XXX.log")
-TMPS=${TMPF%.log}.txt
+TMPS=${TMPF%.log}.stats
+TMPE=${TMPF%.log}.errs
+TMPL=${TMPF%.log}.shots
 
 if [[ $# -eq 1 ]] && [[ -f "$1" ]] && [[ "$1" =~ \.log$ ]]
 then
@@ -47,16 +52,32 @@ fi
 [[ -s "$LOG" ]] || exit 12
 
 echo -e "\033[36m"
-realpath -m "$LOG" "$TMPF" "$TMPS"
+realpath -m "$LOG" "$TMPF" "$TMPE" "$TMPS" "$TMPL"
 
 echo -e "\033[31m"
 grep -e ERROR -e CRITICAL "$LOG" \
 | grep -vFf "$IGNORE" \
 | cut -d'|' -f2 \
 | sort \
+| tee "$TMPE" \
 | uniq -c \
 | sort -n \
 | tee "$TMPS"
-echo -e "\033[0m"
 
+echo -e "\033[33m"
+sort -u "$TMPE" -o "$TMPE"
+while IFS= read -r ERR; do
+  grep -Fm1 "$ERR" "$LOG" \
+  | sed 's/^[^\[]*//'
+done < "$TMPE" \
+| tee "$TMPL.2"
+
+echo -e "\033[32m"
+cut -d'|' -f1 "$TMPL.2" \
+| cut -d'#' -f2 \
+| sort -n \
+| tee "$TMPL" \
+| xargs
+
+echo -e "\033[0m"
 [[ ! -s "$TMPS" ]]

--- a/scripts/disruption-errors.sh
+++ b/scripts/disruption-errors.sh
@@ -38,9 +38,8 @@ else
    | grep -e ERROR -e CRITICAL -e 'INFO.*workflow' -e 'INFO.*Logging' \
    | grep -vFf "$IGNORE" \
    | tee "$TMPF"
-   echo "disruption-py: rc ${PIPESTATUS[0]}"
 
-   LOG=$(grep -o 'Logging:.*' "$TMPF" | cut -d' ' -f2)
+   LOG=$(grep -o 'Logging:.*\.log' "$TMPF" | cut -d' ' -f2)
 
 fi
 

--- a/scripts/disruption-errors.sh
+++ b/scripts/disruption-errors.sh
@@ -75,7 +75,7 @@ done < "$TMPE" \
 echo -e "\033[32m"
 cut -d'|' -f1 "$TMPL.2" \
 | cut -d'#' -f2 \
-| sort -n \
+| sort -un \
 | tee "$TMPL" \
 | xargs
 

--- a/scripts/disruption-errors.sh
+++ b/scripts/disruption-errors.sh
@@ -25,7 +25,7 @@ IGNORE="${0%.sh}.ignore"
 
 TMPD="${LOCALSCRATCH:-/tmp}/$USER/disruption-py/.$(date +%F)"
 mkdir -p "$TMPD" || exit 10
-TMPF=$(mktemp -p "$TMPD" "errors-$(date +%s).XXX.log")
+TMPF=$(mktemp -p "$TMPD" "errors-$(date +%s)-XXX.log")
 TMPS=${TMPF%.log}.txt
 
 if [[ $# -eq 1 ]] && [[ -f "$1" ]] && [[ "$1" =~ \.log$ ]]

--- a/scripts/disruption-errors.sh
+++ b/scripts/disruption-errors.sh
@@ -14,14 +14,13 @@
 #
 # usage examples:
 #
-#    disruption-errors.sh -h
 #    disruption-errors.sh -m get_ip_parameters disruption_warning
 #    disruption-errors.sh /path/to/run/output.log
 #    ls /path/to/run/*log | xargs -n1 disruption-errors.sh
 #
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
-IGNORE="${0%.sh}.ignore"
+IGNORE="${BASH_SOURCE[0]%.sh}.ignore"
 
 TMPD="${LOCALSCRATCH:-/tmp}/$USER/disruption-py/.$(date +%F)"
 mkdir -p "$TMPD" || exit 10
@@ -49,7 +48,7 @@ fi
 [[ -s "$LOG" ]] || exit 12
 
 echo -e "\033[36m"
-realpath "$LOG" "$TMPF" "$TMPS"
+realpath -m "$LOG" "$TMPF" "$TMPS"
 
 echo -e "\033[31m"
 grep -e ERROR -e CRITICAL "$LOG" \

--- a/scripts/disruption-errors.sh
+++ b/scripts/disruption-errors.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+# disruption-errors.sh
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+#
+# this script parses a `disruption-py` log file and collects unexpected errors.
+#
+# first, it runs `disruption-py` by passing on any command-line argument, but
+# can optionally digest a previous log file, instead.
+# then, it parses the log file and collects all errors and critical messages,
+# excluding those that match the patterns in the sibling .ignore file.
+# finally, it prints a list of errors, together with their relative frequency.
+#
+# usage examples:
+#
+#    disruption-errors.sh -h
+#    disruption-errors.sh -m get_ip_parameters disruption_warning
+#    disruption-errors.sh /path/to/run/output.log
+#    ls /path/to/run/*log | xargs -n1 disruption-errors.sh
+#
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+IGNORE="${0%.sh}.ignore"
+
+TMPD="${LOCALSCRATCH:-/tmp}/$USER/disruption-py/.$(date +%F)"
+mkdir -p "$TMPD" || exit 10
+TMPF=$(mktemp -p "$TMPD" "errors-$(date +%s).XXX.log")
+TMPS=${TMPF%.log}.txt
+
+if [[ $# -eq 1 ]] && [[ -f "$1" ]] && [[ "$1" =~ \.log$ ]]
+then
+
+   LOG=$1
+
+else
+
+   uv run disruption-py -l info "$@" \
+   | grep -e ERROR -e CRITICAL -e 'INFO.*workflow' -e 'INFO.*Logging' \
+   | grep -vFf "$IGNORE" \
+   | tee "$TMPF"
+   echo "disruption-py: rc ${PIPESTATUS[0]}"
+
+   LOG=$(grep -o 'Logging:.*' "$TMPF" | cut -d' ' -f2)
+
+fi
+
+[[ -n "$LOG" ]] || exit 11
+[[ -s "$LOG" ]] || exit 12
+
+echo -e "\033[36m"
+realpath "$LOG" "$TMPF" "$TMPS"
+
+echo -e "\033[31m"
+grep -e ERROR -e CRITICAL "$LOG" \
+| grep -vFf "$IGNORE" \
+| cut -d'|' -f2 \
+| sort \
+| uniq -c \
+| sort -n \
+| tee "$TMPS"
+echo -e "\033[0m"
+
+[[ ! -s "$TMPS" ]]


### PR DESCRIPTION
this script parses a `disruption-py` log file and collects unexpected errors.

- first, it runs `disruption-py` by passing on any command-line argument, but can optionally digest a previous log file, instead.
- then, it parses the log file and collects all errors and critical messages, excluding those that match the patterns in the sibling .ignore file.
- finally, it prints a useful summary, consisting of:

  - a :red_circle: list of unique errors, together with their relative frequency;
  - a :yellow_circle: list of error examples, one per unique error;
  - a :green_circle: list of shot numbers, one per unique error.

usage examples:
```
disruption-errors.sh -m get_ip_parameters disruption_warning
disruption-errors.sh /path/to/run/output.log
ls /path/to/run/*log | xargs -n1 disruption-errors.sh
```
