### PR TITLE
Fix double-cached physics methods

### DIFF
--- a/disruption_py/machine/cmod/thomson.py
+++ b/disruption_py/machine/cmod/thomson.py
@@ -5,6 +5,7 @@
 import numpy as np
 import scipy
 
+from disruption_py.core.physics_method.caching import cache_method
 from disruption_py.core.physics_method.params import PhysicsMethodParams
 from disruption_py.core.utils.math import interp1
 from disruption_py.inout.mds import mdsExceptions
@@ -271,6 +272,7 @@ class CmodThomsonDensityMeasure:
         return t, z, n_e, n_e_sig
 
     @staticmethod
+    @cache_method
     def _efit_rz2psi(params: PhysicsMethodParams, r, z, t, tree="analysis"):
         """
         Interpolate the magnetic flux function (psi) from R and Z coordinates.

--- a/disruption_py/machine/east/physics.py
+++ b/disruption_py/machine/east/physics.py
@@ -7,6 +7,7 @@ Module for retrieving and calculating data for EAST physics methods.
 import numpy as np
 import scipy
 
+from disruption_py.core.physics_method.caching import cache_method
 from disruption_py.core.physics_method.decorator import physics_method
 from disruption_py.core.physics_method.params import PhysicsMethodParams
 from disruption_py.core.utils.math import interp1, matlab_smooth
@@ -411,6 +412,7 @@ class EastPhysicsMethods:
         return {"n_e": ne, "greenwald_fraction": greenwald_fraction, "dn_dt": dn_dt}
 
     @staticmethod
+    @cache_method
     def _get_raw_axuv_data(params: PhysicsMethodParams):
         """
         Get the raw (uncalibrated) data from the AXUV arrays for calculating
@@ -1455,6 +1457,7 @@ class EastPhysicsMethods:
         return {"h98": h98_y2}
 
     @staticmethod
+    @cache_method
     def _get_efit_gaps(params: PhysicsMethodParams, tree: str = "_efit_tree"):
         """
         Hidden method to calculate the EFIT and P-EFIT gaps

--- a/disruption_py/machine/hbtep/physics.py
+++ b/disruption_py/machine/hbtep/physics.py
@@ -26,7 +26,6 @@ class HbtepPhysicsMethods:
     """
 
     @staticmethod
-    @cache_method
     @physics_method(columns=["ip"], tokamak=Tokamak.HBTEP)
     def get_ip(params: PhysicsMethodParams):
         """
@@ -55,7 +54,6 @@ class HbtepPhysicsMethods:
         return {"i_vfc": i_vfc, "i_ohc": i_ohc}
 
     @staticmethod
-    @cache_method
     @physics_method(columns=["r", "aminor"], tokamak=Tokamak.HBTEP)
     def get_plasma_radii(params: PhysicsMethodParams):
         """
@@ -134,7 +132,6 @@ class HbtepPhysicsMethods:
         return {"r": r, "aminor": aminor}
 
     @staticmethod
-    @cache_method
     @physics_method(columns=["btor"], tokamak=Tokamak.HBTEP)
     def get_btor(params: PhysicsMethodParams):
         """

--- a/disruption_py/machine/mast/physics.py
+++ b/disruption_py/machine/mast/physics.py
@@ -7,7 +7,6 @@ Physics methods for MAST.
 
 import numpy as np
 
-from disruption_py.core.physics_method.caching import cache_method
 from disruption_py.core.physics_method.decorator import physics_method
 from disruption_py.core.physics_method.errors import CalculationError
 from disruption_py.core.physics_method.params import PhysicsMethodParams

--- a/disruption_py/machine/mast/physics.py
+++ b/disruption_py/machine/mast/physics.py
@@ -23,7 +23,6 @@ class MastPhysicsMethods:
     """
 
     @staticmethod
-    @cache_method
     @physics_method(
         columns=["ip", "dip_dt", "ip_prog", "dipprog_dt"],
         tokamak=Tokamak.MAST,


### PR DESCRIPTION
- do not double-cache physics methods, as they are already cached by their decorator,
- also, cache a couple of minor private methods.