### PR TITLE
Make test_tokamak_parameter spawn-safe

### DIFF
--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -17,27 +17,31 @@ from disruption_py.settings import LogSettings, RetrievalSettings
 from disruption_py.workflow import get_shots_data
 
 
-@pytest.mark.parametrize("tok", [None, resolve_tokamak_from_environment()])
-def test_tokamak_parameter(shotlist, tok, test_folder_f):
+# Module-scope so spawn/forkserver workers can unpickle the function reference.
+@physics_method(columns=["x"])
+def _physics_method_any_tokamak(params: PhysicsMethodParams):
+    return {"x": params.times**0}
+
+
+@physics_method(columns=["x"], tokamak=resolve_tokamak_from_environment())
+def _physics_method_specific_tokamak(params: PhysicsMethodParams):
+    return {"x": params.times**0}
+
+
+@pytest.mark.parametrize(
+    "method",
+    [_physics_method_any_tokamak, _physics_method_specific_tokamak],
+    ids=["tokamak=None", "tokamak=resolved"],
+)
+def test_tokamak_parameter(shotlist, method, test_folder_f):
     """
     Ensure physics methods run when the tokamak parameter is set as either
     `None` or a specific tokamak.
     """
-    col_name = "x"
-
-    # The physics method needs to be defined in the global scope because
-    # multiprocessing and pickling don't work with locally-defined functions.
-    # pylint: disable-next=global-variable-undefined
-    global my_physics_method
-
-    @physics_method(columns=[col_name], tokamak=tok)
-    def my_physics_method(params: PhysicsMethodParams):
-        return {col_name: params.times**0}
-
     retrieval_settings = RetrievalSettings(
-        run_columns=[col_name],
+        run_columns=["x"],
         only_requested_columns=True,
-        custom_physics_methods=[my_physics_method],
+        custom_physics_methods=[method],
     )
     shot_data = get_shots_data(
         shotlist_setting=shotlist[:1],
@@ -48,7 +52,7 @@ def test_tokamak_parameter(shotlist, tok, test_folder_f):
             file_path=os.path.join(test_folder_f, "output.log"),
         ),
     )
-    assert col_name in shot_data.data_vars
+    assert "x" in shot_data.data_vars
     assert shotlist[0] in shot_data.shot
     assert len(shot_data.time)
-    assert all(shot_data[col_name].values == 1)
+    assert all(shot_data["x"].values == 1)


### PR DESCRIPTION
## Summary

  Fix `tests/test_decorator.py::test_tokamak_parameter[None]` hanging indefinitely under multiprocessing's `spawn` start method (macOS default; Linux default in Python 3.14+).

  ## Root cause

  The test defined `my_physics_method` as a function-local `global`. Under `fork` (current Linux default), spawned workers inherit the parent process's module globals, so the attribute exists. Under `spawn`/`forkserver`, workers
  re-import the test module from scratch — `my_physics_method` doesn't exist yet because the test function hasn't run there — so unpickling the function reference fails:

  AttributeError: Can't get attribute 'my_physics_method' on <module 'test_decorator'>

  The worker dies silently; the parent pool waits forever on `queue.get()`.

  ## Fix

  Move the two physics-method variants to module scope and parametrize over the method rather than the tokamak argument. Module-scope functions exist at import time, so spawned workers can find them by reference.

  No production code changes.

  ## Why this matters now

  Python 3.14 makes `forkserver` the default POSIX start method. The current pattern works on Linux CI today only because it forks; that breaks when the project moves to 3.14. This fix preempts the Linux-CI failure as well as fixing the
   existing macOS hang, and unblocks the macOS test matrix being introduced on `glt/macbook`.

  ## Behavior change

  Test IDs change:
  - `test_tokamak_parameter[None]` → `test_tokamak_parameter[tokamak=None]`
  - `test_tokamak_parameter[Tokamak.<X>]` → `test_tokamak_parameter[tokamak=resolved]`

  ## Test plan

  - [x] `pytest tests/test_decorator.py::test_tokamak_parameter` — both parametrizations pass in ~16s on macOS (spawn default)
  - [x] `make black` / ruff / pylint clean on changed file
  - [ ] CI: confirm Linux fork path still passes