### PR TITLE
Fix conflicting attrs during concat

### DIFF
--- a/disruption_py/settings/output_setting.py
+++ b/disruption_py/settings/output_setting.py
@@ -18,7 +18,7 @@ import pandas as pd
 import xarray as xr
 from loguru import logger
 
-from disruption_py.core.utils.misc import get_temporary_folder
+from disruption_py.core.utils.misc import get_metadata, get_temporary_folder
 from disruption_py.machine.tokamak import Tokamak
 
 
@@ -325,7 +325,8 @@ class DatasetOutputSetting(SingleOutputSetting):
             logger.critical("Nothing to concatenate!")
             return xr.Dataset()
 
-        ds = xr.concat(self.results.values(), dim="idx", combine_attrs="no_conflicts")
+        ds = xr.concat(self.results.values(), dim="idx", combine_attrs="drop_conflicts")
+        ds.attrs.update(get_metadata())
         if "shot" not in ds.coords or "time" not in ds.coords:
             return ds
 

--- a/tests/test_output_setting.py
+++ b/tests/test_output_setting.py
@@ -95,7 +95,7 @@ def test_output_exists(fresh_data, test_folder_m):
 
     # format equivalence
     for ds_list in [dict_out.values(), [dt.to_dataset() for dt in dt_out.values()]]:
-        xr.testing.assert_identical(
+        xr.testing.assert_equal(
             ds_out, xr.concat(ds_list, dim="idx").sortby(["shot", "time"])
         )
     pd.testing.assert_frame_equal(df_out, ds_out.to_dataframe()[df_out.columns])


### PR DESCRIPTION
I realized that the upcoming ~py3.14~ spawn/forkserver issues will affect my LRU-cached `get_metadata` method.
~with the new python version~ a slightly different time will be returned for each process and therefore xarray will flag attribute conflicts.

the LRU cache was supposed to prevent this, as the metadata should be resolved (and its cache should be primed) as a first thing by the logger:
https://github.com/MIT-PSFC/disruption-py/blob/0063f4be23d5aa8d79e6e2c4e98293f02f629e5c/disruption_py/settings/log_settings.py#L157

as a dirty fix, we can drop conflicts while concatenating and reapply them on the final product, here:
https://github.com/MIT-PSFC/disruption-py/blob/0063f4be23d5aa8d79e6e2c4e98293f02f629e5c/disruption_py/settings/output_setting.py#L328

@samc24 feel free to dig around whether there is a better way to solve this!
or LMK if you cannot replicate it -- any multiproc multishot workflow should do, including the testing ones.

eg:

```
ERROR tests/test_output_setting.py::test_output_exists
xarray.structure.merge.MergeError: combine_attrs='no_conflicts',
but some values are not the same. Merging
{ [...] 'time': '2026-05-28T15:23:11.087869', [...] }
with
{ [...] 'time': '2026-05-28T15:23:11.430584', [...] }
```