### PR TITLE
Stamp workflow metadata in the main process

### DIFF
--- a/disruption_py/core/physics_method/runner.py
+++ b/disruption_py/core/physics_method/runner.py
@@ -19,7 +19,7 @@ from disruption_py.core.physics_method.metadata import (
     is_physics_method,
 )
 from disruption_py.core.physics_method.params import PhysicsMethodParams
-from disruption_py.core.utils.misc import get_elapsed_time, get_metadata, to_tuple
+from disruption_py.core.utils.misc import get_elapsed_time, to_tuple
 from disruption_py.inout.mds import mdsExceptions
 from disruption_py.machine.method_holders import get_method_holders
 from disruption_py.settings.retrieval_settings import RetrievalSettings
@@ -287,7 +287,6 @@ def populate_shot(
     # set attributes for dataset
     tokamak = physics_method_params.tokamak
     dataset.attrs.update({"tokamak": tokamak.name})
-    dataset.attrs.update(get_metadata())
 
     # set attributes for data vars
     attributes = config(tokamak).get("physics", {}).get("attributes", {})

--- a/disruption_py/workflow.py
+++ b/disruption_py/workflow.py
@@ -21,6 +21,7 @@ from disruption_py.core.retrieval_manager import RetrievalManager
 from disruption_py.core.utils.misc import (
     filter_dict,
     get_elapsed_time,
+    get_metadata,
     get_temporary_folder,
     without_duplicates,
 )
@@ -193,6 +194,9 @@ def get_shots_data(
         ):
             if shot_data is not None:
                 num_success += 1
+                # stamp workflow metadata in the main process, as under
+                # spawn/forkserver each worker would resolve its own time
+                shot_data.attrs.update(get_metadata())
                 output_setting.output_shot(
                     OutputSettingParams(
                         shot_id=shot_id,


### PR DESCRIPTION
Supersedes #561, which is closed in favor of this approach.

## Problem

Under spawn/forkserver, `xr.concat(..., combine_attrs="no_conflicts")` in `DatasetOutputSetting.concat` raises a MergeError because the per-shot datasets carry slightly different `time` attrs. This is also the root cause of the long-standing `test_output_exists` flakiness.

## Root cause

`get_metadata()` is LRU-cached and primed once by the logger, but only in the main process. The stamp was applied in the worker (`populate_shot`), and under spawn each worker is a fresh interpreter that re-primes its own cache with its own microsecond `time`. Same family as #546 and #560 (spawn doesn't inherit parent state). The flakiness came from `pool.imap` distribution: both shots landing on one worker shared the same cached time and passed, splitting them across workers tripped the MergeError.

## Fix

Move the stamp from the worker to the main process, in the `pool.imap` loop in `workflow.py`. The main-process cache is primed once at `setup_logging()`, so every shot carries identical attrs regardless of start method and concat never sees a conflict.

## Why this instead of drop_conflicts

- Keeps `combine_attrs="no_conflicts"` as a tripwire rather than silently dropping conflicting attrs.
- Keeps `assert_identical` in `test_output_setting` untouched. That test rebuilds the concatenated Dataset from the per-shot dict and datatree pieces, so the metadata has to sit on every per-shot object. Dropping and reapplying only on the final product would force `assert_identical` down to `assert_equal`.
- Per-shot outputs (dict folder, datatree children) carry the same run metadata as the final product.
- `output_setting.py` no longer needs to import `get_metadata`, so the output layer stays metadata-agnostic.

## Testing

Verified on MAST (macOS, spawn, 2 fast shots / 2 processes): dev reproduces the MergeError (attrs differ only in `time`), this branch passes `test_output_exists` with `assert_identical` untouched, and `make test-fast` is green.
