### PR TITLE
Introduce macos tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,11 @@ jobs:
 
 
   pytest:
-    runs-on: ubuntu-22.04
+    name: >
+      ${{ startsWith(matrix.os, 'macos')
+      && 'pytest (macos)'
+      || format('pytest ({0})', matrix.tokamak) }}
+    runs-on: ${{ matrix.os }}
     if: |
       github.event_name == 'push' ||
       github.event.pull_request.draft == false
@@ -29,6 +33,16 @@ jobs:
           - DIII-D
           - HBT-EP
           - MAST
+        os:
+          - ubuntu-22.04
+          - macos-15-intel
+        exclude:
+          - tokamak: C-MOD
+            os: macos-15-intel
+          - tokamak: DIII-D
+            os: macos-15-intel
+          - tokamak: HBT-EP
+            os: macos-15-intel
     steps:
 
       - name: Checkout


### PR DESCRIPTION
- introduce a remote test for MAST data that runs on a macos-based runner

... it seems to be painfully slow, so we might want to tweak it or remove it in the future, but at least it works now!