### PR TITLE
Resolve LogSettings defaults from configuration

### DIFF
--- a/disruption_py/config.toml
+++ b/disruption_py/config.toml
@@ -1,3 +1,9 @@
+[default.log]
+file_level = "DEBUG"
+info_threshold = 50
+success_threshold = 500
+warning_threshold = 1000
+
 [default.tests]
 match_fraction = 0.95 # Fraction of signals that must match between MDSplus and SQL
 val_tolerance = 0.01 # Tolerance for comparing values between MDSplus and SQL

--- a/disruption_py/settings/log_settings.py
+++ b/disruption_py/settings/log_settings.py
@@ -15,6 +15,7 @@ from typing import Union
 from loguru import logger
 from tqdm.auto import tqdm
 
+from disruption_py.config import config
 from disruption_py.core.utils.misc import get_metadata, get_temporary_folder
 
 # Register logger state at module import time so it is available in every
@@ -48,13 +49,20 @@ class LogSettings:
     """
     Settings for configuring logging.
 
+    Defaults for `file_level` and the console thresholds are read from the
+    `[log]` section of the layered configuration (repo `config.toml`, then
+    `~/.config/disruption-py/user.toml`, then `DISPY_LOG__*` environment
+    variables, e.g. `DISPY_LOG__WARNING_THRESHOLD=2000`). Values passed
+    explicitly always take precedence over the configuration.
+
     Attributes
     ----------
     file_path : str, optional
         Path to the log file. If None, no log file will be created.
         By default, a log file will be created in a temporary folder.
-    file_level : str
-        Logging level for the log file (default is "DEBUG").
+    file_level : str, optional
+        Logging level for the log file. Default is None, so the level is read
+        from the configuration (`log.file_level`, "DEBUG" out of the box).
         Possible values are:
         "TRACE", "DEBUG", "VERBOSE" (custom), "INFO", "SUCCESS", "WARNING", "ERROR", "CRITICAL".
         See: https://loguru.readthedocs.io/en/stable/api/logger.html#levels
@@ -64,28 +72,45 @@ class LogSettings:
         Possible values are:
         "TRACE", "DEBUG", "VERBOSE" (custom), "INFO", "SUCCESS", "WARNING", "ERROR", "CRITICAL".
         See: https://loguru.readthedocs.io/en/stable/api/logger.html#levels
-    warning_threshold : int
+    warning_threshold : int, optional
         If number of shots is greater than this threshold, the console log level will
-        be "WARNING". Default is 1000.
-    success_threshold : int
+        be "WARNING". Default is None, so the value is read from the configuration
+        (`log.warning_threshold`, 1000 out of the box).
+    success_threshold : int, optional
         If number of shots is greater than this threshold and less than the warning_threshold,
-        the console log level will be "SUCCESS". Default is 500.
-    info_threshold : int
+        the console log level will be "SUCCESS". Default is None, so the value is read
+        from the configuration (`log.success_threshold`, 500 out of the box).
+    info_threshold : int, optional
         If number of shots is greater than this threshold and less than the success_threshold,
-        the console log level will be "INFO". Default is 50.
+        the console log level will be "INFO". Default is None, so the value is read
+        from the configuration (`log.info_threshold`, 50 out of the box).
     _logging_has_been_setup : bool
         Internal flag to prevent multiple setups (default is False).
     """
 
     file_path: str = os.path.join(get_temporary_folder(), "output.log")
-    file_level: str = "DEBUG"
+    file_level: str = None
     console_level: str = None
 
-    warning_threshold: int = 1000
-    success_threshold: int = 500
-    info_threshold: int = 50
+    warning_threshold: int = None
+    success_threshold: int = None
+    info_threshold: int = None
 
     _logging_has_been_setup: bool = False
+
+    def __post_init__(self):
+        # Resolve unset tunables from the layered config (repo config.toml,
+        # user.toml, DISPY_LOG__* environment variables). Explicit arguments
+        # always win.
+        log_config = config().log
+        if self.file_level is None:
+            self.file_level = log_config.file_level
+        if self.warning_threshold is None:
+            self.warning_threshold = log_config.warning_threshold
+        if self.success_threshold is None:
+            self.success_threshold = log_config.success_threshold
+        if self.info_threshold is None:
+            self.info_threshold = log_config.info_threshold
 
     def reset_handlers(self, num_shots: int = None):
         """

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,7 +4,8 @@
 
 import os
 
-from disruption_py.config import config
+from disruption_py.config import config, configs
+from disruption_py.settings import LogSettings
 
 
 def change_directory(test, tmpdir="/tmp"):
@@ -36,3 +37,44 @@ def test_access_tokamak_settings(tokamak):
     Test each tokamak's unique settings are accessible.
     """
     assert config(tokamak)
+
+
+def test_log_settings_defaults_from_config():
+    """
+    Unset LogSettings fields are resolved from the [log] config section.
+    """
+    settings = LogSettings()
+    assert settings.file_level == config().log.file_level
+    assert settings.warning_threshold == config().log.warning_threshold
+    assert settings.success_threshold == config().log.success_threshold
+    assert settings.info_threshold == config().log.info_threshold
+
+
+def test_log_settings_env_override(monkeypatch):
+    """
+    DISPY_LOG__* environment variables override the config file defaults.
+    """
+    monkeypatch.setenv("DISPY_LOG__WARNING_THRESHOLD", "2000")
+    monkeypatch.setenv("DISPY_LOG__FILE_LEVEL", "INFO")
+    # drop the cached config so the environment variables are re-read
+    configs.pop("default", None)
+    try:
+        settings = LogSettings()
+        assert settings.warning_threshold == 2000
+        assert settings.file_level == "INFO"
+        # untouched fields still come from the config file
+        assert settings.success_threshold == 500
+    finally:
+        # rebuild the cache without the overrides for subsequent tests
+        configs.pop("default", None)
+
+
+def test_log_settings_argument_wins():
+    """
+    Explicitly passed values take precedence over the configuration.
+    """
+    settings = LogSettings(warning_threshold=7, file_level="ERROR")
+    assert settings.warning_threshold == 7
+    assert settings.file_level == "ERROR"
+    # unset fields still resolve from the configuration
+    assert settings.info_threshold == config().log.info_threshold


### PR DESCRIPTION
Prototype for #445: move hardcoded tunables into the layered configuration, using `LogSettings` as the proof of pattern.

- `file_level`, `console_level` and the console thresholds (`warning_threshold`, `success_threshold`, `info_threshold`) default to `None` and are resolved in `__post_init__` from the `[default.log]` section of `config.toml`. An unset `console_level` keeps the existing meaning: derive the level from the shot count.
- Precedence: explicit argument, then `DISPY_LOG__*` environment variable, then `~/.config/disruption-py/user.toml`, then the repo `config.toml`. The env and user-file layers come for free from the existing Dynaconf setup, e.g. `DISPY_LOG__CONSOLE_LEVEL=INFO`.
- The effective log settings are written back into the configuration inside `get_shots_data` before the per-run `config.json` dump, which now runs after the retrieval and output settings are resolved. The dump therefore reflects the runtime values for both CLI and API callers.
- The CLI `-l` default comes from the same config lookup instead of a hardcoded VERBOSE, so command-line runs get the dynamic level like the API. This is the one behaviour change.
- The file log level is floored at the console level: `-l TRACE` lowers both sinks, while a dynamic WARNING console on a large run leaves the file at DEBUG.
- `file_path` stays out of the config since it is a computed per-run default that needs its own design call. Log settings remain machine-independent by construction: logging is set up before the tokamak is resolved, so the `default` environment is the only possible source.
- Explicitly passed values always win, and the config defaults match the previous hardcoded values. Workers under spawn are unaffected since the settings are resolved in the main process before pickling.
- Tests in `tests/test_config.py` cover precedence, the config round-trip and write-back, and the file-level floor.

Not in this PR: the remaining CLI defaults (efit tree, time base, output, processes). Moving those means the dataclass defaults read config too and the resolved settings objects need a JSON form for the dump, which overlaps the settings revamp.
