### PR TITLE
Tweak dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,5 +8,11 @@ updates:
     target-branch: "dev"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 7
+    groups:
+      deps:
+        patterns:
+          - "*"
     reviewers:
       - gtrevisan


### PR DESCRIPTION
- add one week of cooldown
- group PRs

reference:
- https://github.blog/security/supply-chain-security/tame-dependabot-group-your-updates-slow-the-cadence-keep-security-fast/

