### PR TITLE
Make find invocations in the makefile BSD-compatible

### DIFF
--- a/makefile
+++ b/makefile
@@ -28,12 +28,12 @@ fetch:
 .PHONY: clean-list clean-delete
 
 clean-list:
-	echo $(DELETE_OBJS) | xargs -n1 find -name
-	find -type d -empty
+	echo $(DELETE_OBJS) | xargs -n1 find . -name
+	find . -type d -empty
 
 clean-delete:
-	echo $(DELETE_OBJS) | xargs -n1 find -name | xargs rm -rfv
-	find -type d -empty -delete
+	echo $(DELETE_OBJS) | xargs -n1 find . -name | xargs rm -rfv
+	find . -type d -empty -delete
 
 # poetry #
 
@@ -135,7 +135,7 @@ shellcheck:
 	   RC=$$?; \
 	   echo "--> $$F = $$RC"; \
 	   [ "$$RC" -eq 0 ] || KO=1; \
-	done < <(find -type f -not -path '*/.git/*' -not -path '*/.venv/*' -print0); \
+	done < <(find . -type f -not -path '*/.git/*' -not -path '*/.venv/*' -print0); \
 	exit "$$KO"
 
 yamllint:
@@ -149,7 +149,7 @@ yamllint:
 	   RC=$$?; \
 	   echo "--> $$F = $$RC"; \
 	   [ "$$RC" -eq 0 ] || KO=1; \
-	done < <(find -type f -iname '*.y*ml' -not -empty -not -path '*/.venv/*' -print0); \
+	done < <(find . -type f -iname '*.y*ml' -not -empty -not -path '*/.venv/*' -print0); \
 	exit "$$KO"
 
 toml-sort:
@@ -163,7 +163,7 @@ toml-sort:
 	   RC=$$?; \
 	   echo "--> $$F = $$RC"; \
 	   [ "$$RC" -eq 0 ] || KO=1; \
-	done < <(find -maxdepth 1 -type f -iname '*.toml' -not -empty -not -path '*/.venv/*' -print0); \
+	done < <(find . -maxdepth 1 -type f -iname '*.toml' -not -empty -not -path '*/.venv/*' -print0); \
 	while IFS= read -r -d '' F; \
 	do \
 	   echo "--> $$F"; \
@@ -171,5 +171,5 @@ toml-sort:
 	   RC=$$?; \
 	   echo "--> $$F = $$RC"; \
 	   [ "$$RC" -eq 0 ] || KO=1; \
-	done < <(find -mindepth 2 -type f -iname '*.toml' -not -empty -not -path '*/.venv/*' -print0); \
+	done < <(find . -mindepth 2 -type f -iname '*.toml' -not -empty -not -path '*/.venv/*' -print0); \
 	exit "$$KO"


### PR DESCRIPTION
The shellcheck, yamllint, and toml-sort targets invoke `find` without a start path, which is a GNU extension. On macOS, BSD find rejects this with `illegal option`, the error is swallowed by the process substitution feeding the while loop, and the target exits 0 having checked zero files. So these three checks pass vacuously on any Mac, which is how the toml-sort failure on #569 made it to CI instead of being caught locally. The clean-list and clean-delete targets have the same pathless calls and simply error out.

This adds the explicit `.` start path, which both implementations accept.

- No change for CI: on Ubuntu 22.04 with GNU findutils 4.9.0, each of the touched find expressions produces byte-identical output with and without the explicit `.` (GNU assumes `.` when no path is given).
- On macOS all seven lint targets now genuinely run: shellcheck iterates `scripts/disruption-errors.sh`, yamllint the YAML files, toml-sort the TOML files, and `GITHUB_ACTIONS=true make lint` exits 0 end to end. The clean targets work as well.
- No extra install needed on macOS: shellcheck is already available through the venv since `shellcheck-py` is in the lock, so `poetry run make lint` picks it up.
