### PR TITLE
Resolve type consistency in C-Mod validity range metadata

### DIFF
--- a/disruption_py/machine/cmod/config.toml
+++ b/disruption_py/machine/cmod/config.toml
@@ -19,13 +19,13 @@ units = "m"
 description = "Normalized plasma beta computed from EFIT."
 imas = "/summary/global_quantities/beta_tor_norm"
 units = "dimensionless"
-validity = [0, 2]
+validity = [0.0, 2.0]
 
 [cmod.physics.attributes.beta_p]
 description = "Beta poloidal (EFIT)."
 imas = "/equilibrium/time_slice(itime)/global_quantities/beta_pol"
 units = "dimensionless"
-validity = [0, 1.5]
+validity = [0.0, 1.5]
 
 [cmod.physics.attributes.bt]
 description = "Toroidal magnetic field strength."
@@ -35,7 +35,7 @@ units = "T"
 [cmod.physics.attributes.chisq]
 description = "Magnetic chi^2 (EFIT)."
 units = "dimensionless"
-validity = [0.1, 40]
+validity = [0.1, 40.0]
 
 [cmod.physics.attributes.current_quench_time]
 description = "Time of the current quench event. NaN for non-disruptive discharges."
@@ -79,7 +79,7 @@ units = "J/s"
 description = "Greenwald fraction."
 imas = "/summary/global_quantities/greenwald_fraction/value"
 units = "dimensionless"
-validity = [0, 1.5]
+validity = [0.0, 1.5]
 
 [cmod.physics.attributes.i_efc]
 description = "Error field correction (EFC) coil current."
@@ -103,13 +103,13 @@ units = "A"
 description = "Elongation at plasma boundary (EFIT)."
 imas = "/equilibrium/time_slice(itime)/boundary/elongation"
 units = "dimensionless"
-validity = [0.8, 2]
+validity = [0.8, 2.0]
 
 [cmod.physics.attributes.kappa_area]
 description = "Elongation calculated using the plasma area and minor radius from EFIT."
 imas = "/summary/boundary/elongation"
 units = "dimensionless"
-validity = [0.8, 2]
+validity = [0.8, 2.0]
 
 [cmod.physics.attributes.li]
 description = "Normalized internal inductance, li(3) (EFIT)."
@@ -127,13 +127,13 @@ validity = [0.025, 0.25]
 description = "Measured line-averaged electron density."
 imas = "/summary/line_average/n_e/value"
 units = "m^-3"
-validity = [0.2e20, 7e20]
+validity = [0.2e20, 7.0e20]
 
 [cmod.physics.attributes.n_equal_1_mode]
 description = "Amplitude of the n=1 mode."
 imas = "/mhd_linear/time_slice(itime)/toroidal_mode(i1)/plasma/b_field_perturbed"
 units = "T"
-validity = [0, 0.02]
+validity = [0.0, 0.02]
 
 [cmod.physics.attributes.n_equal_1_normalized]
 description = "Amplitude of the n=1 mode normalized to the toroidal magnetic field."
@@ -146,7 +146,7 @@ units = "rad"
 [cmod.physics.attributes.n_over_ncrit]
 description = "Vertical stability parameter, vacuum field index normalized to critical index. (EFIT)."
 units = "dimensionless"
-validity = [-3, 3]
+validity = [-3.0, 3.0]
 
 [cmod.physics.attributes.ne_peaking]
 description = "Peaking factor of the electron density profile measured by the Thomson scattering diagnostic."
@@ -156,7 +156,7 @@ units = "dimensionless"
 description = "Total ion cyclotron resonant heating power."
 imas = "/summary/heating_current_drive/power_launched_ic/value"
 units = "W"
-validity = [0, inf]
+validity = [0.0, inf]
 
 [cmod.physics.attributes.p_input]
 description = "Total input power (ohmic + LH + ICRF)."
@@ -166,19 +166,19 @@ units = "W"
 description = "Total lower hybrid heating power."
 imas = "/summary/heating_current_drive/power_launched_lh/value"
 units = "W"
-validity = [0, inf]
+validity = [0.0, inf]
 
 [cmod.physics.attributes.p_oh]
 description = "Total Ohmic heating power."
 imas = "/summary/global_quantities/power_ohm/value"
 units = "W"
-validity = [0, 5.0e6]
+validity = [0.0, 5.0e6]
 
 [cmod.physics.attributes.p_rad]
 description = "Total radiated power measured by the 2pi diode."
 imas = "/bolometer/power_radiated_total"
 units = "W"
-validity = [0, inf]
+validity = [0.0, inf]
 
 [cmod.physics.attributes.prad_peaking]
 description = "Peaking factor of the radiated power."
@@ -192,23 +192,23 @@ units = "dimensionless"
 description = "Safety factor at magnetic axis (EFIT)."
 imas = "/equilibrium/time_slice(itime)/global_quantities/q_axis"
 units = "dimensionless"
-validity = [0, 2]
+validity = [0.0, 2.0]
 
 [cmod.physics.attributes.q95]
 description = "Safety factor at 95% flux surface (EFIT)."
 imas = "/equilibrium/time_slice(itime)/global_quantities/q_95"
 units = "dimensionless"
-validity = [0, inf]
+validity = [0.0, inf]
 
 [cmod.physics.attributes.qstar]
 description = "Equivalent (kink) safety factor (EFIT)."
 units = "dimensionless"
-validity = [0, inf]
+validity = [0.0, inf]
 
 [cmod.physics.attributes.radiated_fraction]
 description = "Total radiated power fraction."
 units = "dimensionless"
-validity = [0, 15]
+validity = [0.0, 15.0]
 
 [cmod.physics.attributes.rmagx]
 description = "Major radius of magnetic axis (EFIT)."
@@ -218,7 +218,7 @@ units = "m"
 [cmod.physics.attributes.ssep]
 description = "Outboard radial distance to external second separatrix for single null configurations. Positive for single top-null and negative for single bottom-null. Near-zero for double-null (EFIT)."
 units = "m"
-validity = [-1, 1]
+validity = [-1.0, 1.0]
 
 [cmod.physics.attributes.sxr]
 description = "Core soft X-ray measurement."
@@ -268,18 +268,18 @@ units = "dimensionless"
 description = "Top gap between x-point and wall (EFIT)."
 imas = "/equilibrium/time_slice(itime)/boundary/gap(i1)/value"
 units = "m"
-validity = [0, inf]
+validity = [0.0, inf]
 
 [cmod.physics.attributes.v_loop]
 description = "Measured loop voltage."
 imas = "/summary/global_quantities/v_loop/value"
 units = "V"
-validity = [-7, 7]
+validity = [-7.0, 7.0]
 
 [cmod.physics.attributes.v_loop_efit]
 description = "Reconstructed loop voltage (EFIT), smoothed using non-causal filter."
 units = "V"
-validity = [-7, 7]
+validity = [-7.0, 7.0]
 
 [cmod.physics.attributes.v_surf]
 description = "Plasma surface voltage computed from EFIT."
@@ -294,12 +294,12 @@ units = "m/s"
 description = "Total plasma energy (EFIT)."
 imas = "/equilibrium/time_slice(itime)/global_quantities/energy_mhd"
 units = "J"
-validity = [5e3, 3e5]
+validity = [5.0e3, 3.0e5]
 
 [cmod.physics.attributes.z_error]
 description = "Difference between the measured and programmed vertical position of the plasma current centroid."
 units = "m"
-validity = [-1, 1]
+validity = [-1.0, 1.0]
 
 [cmod.physics.attributes.z_prog]
 description = "Programmed vertical position of the plasma current centroid."


### PR DESCRIPTION
# Problem
TOML uses strong typing as it parses the config.toml files.  Disruption-py physics variables write as floats.  
Currently, some validity ranges for C-Mod contain no “.” characters in either the lower or upper bound, prompting TOML to interpret the range bounds as integers (C long long).  This causes the resulting netCDF metadata headers to have a type mismatch when viewed with `ncdump -h`.  While not strictly a problem, this can be cleaned up with edits to the `config.toml`.

Example output from current dev branch:
<img width="1323" height="239" alt="long_long_example_PR" src="https://github.com/user-attachments/assets/0f933c6d-5de5-4c7d-b16d-42f9f83c7e97" />

# Implementation
Performed a pass over validity ranges for all machines and inserted “.” to prompt type translation to float.  Presently, only C-Mod has validity ranges, so all changes were made to `disruption_py/machine/cmod/config.toml`. I have added "." characters to all ints for consistency, even in cases where an int was paired with a float (e.g. `validity = [0.1, 40]` becomes `validity = [0.1, 40.0]`). 

# Out of Scope
- Adding validity ranges to other machines
- Physics review of validity ranges
- Enforcement of Validity ranges

This PR is intended as a lightweight change in support of FY26 milestones.  A full review and functional integration of validity ranges is left for future work.