### PR TITLE
Add metadata for generic physics methods with new config file

### DIFF
--- a/disruption_py/config.py
+++ b/disruption_py/config.py
@@ -45,6 +45,7 @@ def config(tokamak: Union[Enum, str] = None):
             root_path=os.path.dirname(__file__),
             settings_files=[
                 "config.toml",
+                "machine/generic/config.toml",
                 f"machine/{tokamak}/config.toml",
                 user_config,
             ],

--- a/disruption_py/machine/cmod/config.toml
+++ b/disruption_py/machine/cmod/config.toml
@@ -37,10 +37,6 @@ description = "Magnetic chi^2 (EFIT)."
 units = "dimensionless"
 validity = [0.1, 40.0]
 
-[cmod.physics.attributes.current_quench_time]
-description = "Time of the current quench event. NaN for non-disruptive discharges."
-units = "s"
-
 [cmod.physics.attributes.dbetap_dt]
 description = "Time derivative of the poloidal beta (EFIT)."
 units = "s^-1"

--- a/disruption_py/machine/generic/config.toml
+++ b/disruption_py/machine/generic/config.toml
@@ -1,0 +1,7 @@
+[default.physics.attributes.current_quench_time]
+description = "Time of the current quench event. NaN for non-disruptive discharges."
+units = "s"
+
+[default.physics.attributes.time_domain]
+description = "Categorical phase of shot at each time. 1: ramp-up, 2: flat-top, 3: ramp-down."
+units = "dimensionless"


### PR DESCRIPTION
The new `disruption_py/machine/generic/config.toml` file leverages the `default` `Dynaconf` environment to add attributes to the physics methods defined in `disruption_py/machine/generic/physics.py`.

The chosen approach seems to have the smallest impact on the existing codebase, as a single-line edit was made to the current config resolution method in `disruption_py/config.py`.   
Note that the order of the settings files is significant with `environments=True`.  Physics attributes using the `default` environment must resolve before physics attributes that use the `tokamak` environment.