### PR TITLE
Fix get_rt_ip_parameters to return ip_prog_rt as nan when PTDATA polarity read fails.

### DIFF
--- a/disruption_py/machine/d3d/physics.py
+++ b/disruption_py/machine/d3d/physics.py
@@ -809,8 +809,8 @@ class D3DPhysicsMethods:
                 "ip_prog_rt: Failed to get programmed plasma current parameters. Setting to NaN."
             )
             params.logger.opt(exception=True).debug(e)
-            # Return nan if polarity read fails after ip_prog_rt read succeeds.
             ip_prog_rt = [np.nan]
+            dipprog_dt_rt = [np.nan]
         try:
             ip_error_rt, t_ip_error_rt = params.get_data_with_dims(
                 f"ptdata('ipeecoil', {params.shot_id})"

--- a/disruption_py/machine/d3d/physics.py
+++ b/disruption_py/machine/d3d/physics.py
@@ -767,7 +767,8 @@ class D3DPhysicsMethods:
         - original source: [get_Ip_parameters_RT.m](https://github.com/MIT-PSFC/disruption-py
         /blob/matlab/DIII-D/get_Ip_parameters_RT.m)
         - pull requests: #[254](https://github.com/MIT-PSFC/disruption-
-        py/pull/254), #[547](https://github.com/MIT-PSFC/disruption-py/pull/547)
+        py/pull/254), #[547](https://github.com/MIT-PSFC/disruption-py/pull/547),
+        #[596](https://github.com/MIT-PSFC/disruption-py/pull/596)
         - issues: #[506](https://github.com/MIT-PSFC/disruption-py/issues/506)
         """
         ip_rt = [np.nan]

--- a/disruption_py/machine/d3d/physics.py
+++ b/disruption_py/machine/d3d/physics.py
@@ -808,6 +808,8 @@ class D3DPhysicsMethods:
                 "ip_prog_rt: Failed to get programmed plasma current parameters. Setting to NaN."
             )
             params.logger.opt(exception=True).debug(e)
+            # Return nan if polarity read fails after ip_prog_rt read succeeds.
+            ip_prog_rt = [np.nan]
         try:
             ip_error_rt, t_ip_error_rt = params.get_data_with_dims(
                 f"ptdata('ipeecoil', {params.shot_id})"


### PR DESCRIPTION
# Problem

Related to the discussion in PR #592 , the `get_rt_ip_parameters` physics method returns `ip_prog_rt` in its native time base if reading polarity from PTDATA fails.  Physics methods should return data that has been interpolated onto the `PhysicsMethodParams` time base, or they should return `nan`.  

# Solution

Cleaned up the `except` block to set `ip_prog_rt` to `nan` in accordance with the warning message that is already in the method.

# Comments

The `ip_prog_rt` signal may be salvageable in these cases.  However, this would require developing new logic for handling the polarity in cases where it cannot be read.  While these cases are rare, users of this signal are welcome to suggest solutions for us to revisit this method at a later time.