### PR TITLE
Add a mapping to execute SQL queries

### DIFF
--- a/disruption_py/settings/shotlist_setting.py
+++ b/disruption_py/settings/shotlist_setting.py
@@ -13,6 +13,7 @@ from typing import Dict, List, Type, Union
 
 import numpy as np
 import pandas as pd
+from loguru import logger
 
 import disruption_py.data
 from disruption_py.core.utils.enums import map_string_to_enum
@@ -148,6 +149,7 @@ class DatabaseShotlistSetting(ShotlistSetting):
         self.use_pandas = use_pandas
 
     def _get_shotlist(self, params: ShotlistSettingParams) -> List:
+        logger.trace("Executing query: {query}", query=self.sql_query)
         if self.use_pandas:
             query_result_df = params.database.query(
                 query=self.sql_query, use_pandas=True
@@ -183,6 +185,7 @@ _file_suffix_to_shotlist_setting: Dict[str, Type[ShotlistSetting]] = {
     ".txt": FileShotlistSetting,
     ".csv": FileShotlistSetting,
     ".parquet": FileShotlistSetting,
+    ";": DatabaseShotlistSetting,
 }
 # --8<-- [end:file_suffix_to_shotlist_setting_dict]
 


### PR DESCRIPTION
forgot about this old branch that might come in handy. eg:

```
# C-MOD
disruption-py 'select shot from summary where shot between 1150805012 and 1150805022;' -l trace

...

[ TRACE ] Executing query: select shot from summary where shot between 1150805012 and 1150805022;
[ INFO  ] Starting workflow: 11 shots / 1 process
```

```
# DIII-D
disruption-py 'select shot from summaries where pulse_length > 10;' -l trace

...

[ TRACE ] Executing query: select shot from summaries where pulse_length > 10;
[ INFO  ] Starting workflow: 199 shots / 1 process
```