### PR TITLE
Tweak imports in generic module to simplify its own import

### DIFF
--- a/disruption_py/machine/generic/physics.py
+++ b/disruption_py/machine/generic/physics.py
@@ -13,6 +13,9 @@ from disruption_py.core.physics_method.params import PhysicsMethodParams
 from disruption_py.machine.generic.util import GenericUtilMethods
 from disruption_py.machine.tokamak import Tokamak
 
+# importing machine methods at the function level allows machine methods
+# to import generic methods at the module level and avoid cyclic imports
+
 
 class GenericPhysicsMethods:
     """
@@ -53,8 +56,6 @@ class GenericPhysicsMethods:
         - pull requests: #[433](https://github.com/MIT-PSFC/disruption-py/pull/433)
         - issues: #[408](https://github.com/MIT-PSFC/disruption-py/issues/408)
         """
-
-        # function-level imports allow machine methods to import generic methods without circularity
 
         # Initialize dictionaries
         signals = {}
@@ -165,8 +166,6 @@ class GenericPhysicsMethods:
         - pull requests: #[545](https://github.com/MIT-PSFC/disruption-py/pull/545)
         - issues: #[223](https://github.com/MIT-PSFC/disruption-py/issues/223)
         """
-
-        # function-level imports allow machine methods to import generic methods without circularity
 
         # Initialize test criteria
         criteria = {

--- a/disruption_py/machine/generic/physics.py
+++ b/disruption_py/machine/generic/physics.py
@@ -55,11 +55,6 @@ class GenericPhysicsMethods:
         """
 
         # function-level imports allow machine methods to import generic methods without circularity
-        # pylint: disable=import-outside-toplevel, cyclic-import
-        from disruption_py.machine.cmod.physics import CmodPhysicsMethods
-        from disruption_py.machine.d3d.physics import D3DPhysicsMethods
-        from disruption_py.machine.east.physics import EastPhysicsMethods
-        from disruption_py.machine.mast.physics import MastPhysicsMethods
 
         # Initialize dictionaries
         signals = {}
@@ -71,19 +66,31 @@ class GenericPhysicsMethods:
         }
         # Get data and threshold parameters
         if params.tokamak == Tokamak.CMOD:
+            # pylint: disable=import-outside-toplevel, cyclic-import
+            from disruption_py.machine.cmod.physics import CmodPhysicsMethods
+
             ip_parameters = CmodPhysicsMethods.get_ip_parameters(params=params)
             signals["dipprog_dt"] = ip_parameters["dipprog_dt"]
             signals["ip_prog"] = ip_parameters["ip_prog"]
         elif params.tokamak == Tokamak.D3D:
+            # pylint: disable=import-outside-toplevel, cyclic-import
+            from disruption_py.machine.d3d.physics import D3DPhysicsMethods
+
             ip_parameters = D3DPhysicsMethods.get_ip_parameters(params=params)
             psr_parameter = D3DPhysicsMethods.get_power_supply_railed(params=params)
             signals["dipprog_dt"] = ip_parameters["dipprog_dt"]
             signals["ip_prog"] = ip_parameters["ip_prog"]
             signals["power_supply_railed"] = psr_parameter["power_supply_railed"]
         elif params.tokamak == Tokamak.EAST:
+            # pylint: disable=import-outside-toplevel, cyclic-import
+            from disruption_py.machine.east.physics import EastPhysicsMethods
+
             ip_parameters = EastPhysicsMethods.get_ip_parameters(params=params)
             signals["dipprog_dt"] = ip_parameters["dipprog_dt"]
         elif params.tokamak == Tokamak.MAST:
+            # pylint: disable=import-outside-toplevel, cyclic-import
+            from disruption_py.machine.mast.physics import MastPhysicsMethods
+
             ip_parameters = MastPhysicsMethods.get_ip_parameters(params=params)
             signals["dipprog_dt"] = ip_parameters["dipprog_dt"]
             signals["ip_prog"] = ip_parameters["ip_prog"]
@@ -160,8 +167,6 @@ class GenericPhysicsMethods:
         """
 
         # function-level imports allow machine methods to import generic methods without circularity
-        # pylint: disable=import-outside-toplevel, cyclic-import
-        from disruption_py.machine.east.util import EastUtilMethods
 
         # Initialize test criteria
         criteria = {
@@ -191,6 +196,9 @@ class GenericPhysicsMethods:
                 ip_baseline = np.mean(ip[baseline_indices])
                 ip -= ip_baseline
         elif params.tokamak == Tokamak.EAST:
+            # pylint: disable=import-outside-toplevel, cyclic-import
+            from disruption_py.machine.east.util import EastUtilMethods
+
             ip, t_ip = EastUtilMethods.retrieve_ip(params, params.shot_id)
         elif params.tokamak == Tokamak.HBTEP:
             ip, t_ip = params.get_data_with_dims(

--- a/disruption_py/machine/generic/physics.py
+++ b/disruption_py/machine/generic/physics.py
@@ -10,12 +10,7 @@ from disruption_py.config import config
 from disruption_py.core.physics_method.decorator import physics_method
 from disruption_py.core.physics_method.errors import CalculationError
 from disruption_py.core.physics_method.params import PhysicsMethodParams
-from disruption_py.machine.cmod import CmodPhysicsMethods
-from disruption_py.machine.d3d import D3DPhysicsMethods
-from disruption_py.machine.east import EastPhysicsMethods
-from disruption_py.machine.east.util import EastUtilMethods
 from disruption_py.machine.generic.util import GenericUtilMethods
-from disruption_py.machine.mast.physics import MastPhysicsMethods
 from disruption_py.machine.tokamak import Tokamak
 
 
@@ -58,6 +53,14 @@ class GenericPhysicsMethods:
         - pull requests: #[433](https://github.com/MIT-PSFC/disruption-py/pull/433)
         - issues: #[408](https://github.com/MIT-PSFC/disruption-py/issues/408)
         """
+
+        # function-level imports allow machine methods to import generic methods without circularity
+        # pylint: disable=import-outside-toplevel, cyclic-import
+        from disruption_py.machine.cmod.physics import CmodPhysicsMethods
+        from disruption_py.machine.d3d.physics import D3DPhysicsMethods
+        from disruption_py.machine.east.physics import EastPhysicsMethods
+        from disruption_py.machine.mast.physics import MastPhysicsMethods
+
         # Initialize dictionaries
         signals = {}
         thresholds = config(params.tokamak).physics.time_domain_thresholds
@@ -155,6 +158,11 @@ class GenericPhysicsMethods:
         - pull requests: #[545](https://github.com/MIT-PSFC/disruption-py/pull/545)
         - issues: #[223](https://github.com/MIT-PSFC/disruption-py/issues/223)
         """
+
+        # function-level imports allow machine methods to import generic methods without circularity
+        # pylint: disable=import-outside-toplevel, cyclic-import
+        from disruption_py.machine.east.util import EastUtilMethods
+
         # Initialize test criteria
         criteria = {
             "shot_duration": lambda duration, duration_min: duration > duration_min,

--- a/disruption_py/machine/generic/physics.py
+++ b/disruption_py/machine/generic/physics.py
@@ -66,14 +66,14 @@ class GenericPhysicsMethods:
         }
         # Get data and threshold parameters
         if params.tokamak == Tokamak.CMOD:
-            # pylint: disable=import-outside-toplevel, cyclic-import
+            # pylint: disable-next=import-outside-toplevel, cyclic-import
             from disruption_py.machine.cmod.physics import CmodPhysicsMethods
 
             ip_parameters = CmodPhysicsMethods.get_ip_parameters(params=params)
             signals["dipprog_dt"] = ip_parameters["dipprog_dt"]
             signals["ip_prog"] = ip_parameters["ip_prog"]
         elif params.tokamak == Tokamak.D3D:
-            # pylint: disable=import-outside-toplevel, cyclic-import
+            # pylint: disable-next=import-outside-toplevel, cyclic-import
             from disruption_py.machine.d3d.physics import D3DPhysicsMethods
 
             ip_parameters = D3DPhysicsMethods.get_ip_parameters(params=params)
@@ -82,13 +82,13 @@ class GenericPhysicsMethods:
             signals["ip_prog"] = ip_parameters["ip_prog"]
             signals["power_supply_railed"] = psr_parameter["power_supply_railed"]
         elif params.tokamak == Tokamak.EAST:
-            # pylint: disable=import-outside-toplevel, cyclic-import
+            # pylint: disable-next=import-outside-toplevel, cyclic-import
             from disruption_py.machine.east.physics import EastPhysicsMethods
 
             ip_parameters = EastPhysicsMethods.get_ip_parameters(params=params)
             signals["dipprog_dt"] = ip_parameters["dipprog_dt"]
         elif params.tokamak == Tokamak.MAST:
-            # pylint: disable=import-outside-toplevel, cyclic-import
+            # pylint: disable-next=import-outside-toplevel, cyclic-import
             from disruption_py.machine.mast.physics import MastPhysicsMethods
 
             ip_parameters = MastPhysicsMethods.get_ip_parameters(params=params)
@@ -196,7 +196,7 @@ class GenericPhysicsMethods:
                 ip_baseline = np.mean(ip[baseline_indices])
                 ip -= ip_baseline
         elif params.tokamak == Tokamak.EAST:
-            # pylint: disable=import-outside-toplevel, cyclic-import
+            # pylint: disable-next=import-outside-toplevel, cyclic-import
             from disruption_py.machine.east.util import EastUtilMethods
 
             ip, t_ip = EastUtilMethods.retrieve_ip(params, params.shot_id)


### PR DESCRIPTION
this should allow for an easy import of the generic methods from any machine module:
- lower the machine-specific imports in the generic module to their respective function-level scopes, and 
- disable the respectives pylint codes.